### PR TITLE
Reindex index (start, end) when add-on is installed.

### DIFF
--- a/ftw/events/configure.zcml
+++ b/ftw/events/configure.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="ftw.events">
 
     <i18n:registerTranslations directory="locales" />
@@ -38,6 +39,11 @@
     <adapter
         factory=".syndication.EventListingBlockFeed"
         for="ftw.events.interfaces.IEventListingBlock"
+        />
+
+    <profilehook:hook
+        profile="ftw.events:default"
+        handler=".hooks.default_profile_installed"
         />
 
 </configure>

--- a/ftw/events/hooks.py
+++ b/ftw/events/hooks.py
@@ -1,0 +1,18 @@
+from Products.CMFCore.utils import getToolByName
+
+
+def default_profile_installed(portal):
+    reindex_indexes(portal)
+
+
+def reindex_indexes(portal):
+    """
+    `plone.app.events` replaces the start and end index by a
+    RecurringDateIndex (before DateIndex) but it omits to reindex
+    the new index. This causes the loss of the start and end index
+    data of every content. So we need to take care of reindexing
+    the indexes.
+    """
+    catalog = getToolByName(portal, 'portal_catalog')
+    catalog.reindexIndex('start', None)
+    catalog.reindexIndex('end', None)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     install_requires=[
         'Plone',
         'collective.dexteritytextindexer',
+        'ftw.profilehook',
         'ftw.simplelayout [contenttypes]',
         'ftw.upgrade',
         'plone.api',


### PR DESCRIPTION
plone.app.events replaces the start and end index by a RecurringDateIndex (before DateIndex) but it omits to reindex the new index. This causes the loss of the start and end index data of every content. So we need to take care of reindexing the indexes.

Closes https://github.com/4teamwork/ftw.events/issues/5