### PR TITLE
ftw.calendar integration

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- Added ftw.calendar integration. [lknoepfel]
+
 - Don't list EventPage in the navigation [lkoepfel]
 
 - Initial implementation [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,4 +5,6 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- Don't list EventPage in the navigation [lkoepfel]
+
 - Initial implementation [jone]

--- a/ftw/events/hooks.py
+++ b/ftw/events/hooks.py
@@ -2,7 +2,18 @@ from Products.CMFCore.utils import getToolByName
 
 
 def default_profile_installed(portal):
+    set_calendar_types(portal)
     reindex_indexes(portal)
+
+
+def set_calendar_types(context):
+    """
+    Mark `ftw.events.EventPage` as an calendar type in portal_calendar.
+    """
+    portal_calendar = getToolByName(context, 'portal_calendar')
+    types = list(portal_calendar.calendar_types)
+    types.append('ftw.events.EventPage')
+    portal_calendar.calendar_types = tuple(types)
 
 
 def reindex_indexes(portal):

--- a/ftw/events/profiles/default/propertiestool.xml
+++ b/ftw/events/profiles/default/propertiestool.xml
@@ -4,6 +4,7 @@
     <object name="navtree_properties" meta_type="Plone Property Sheet">
         <property name="metaTypesNotToList" type="lines" purge="False">
             <element value="ftw.events.EventListingBlock"/>
+            <element value="ftw.events.EventPage"/>
         </property>
     </object>
 

--- a/ftw/events/profiles/default/types/ftw.events.EventFolder.xml
+++ b/ftw/events/profiles/default/types/ftw.events.EventFolder.xml
@@ -33,6 +33,7 @@
     <property name="default_view">@@simplelayout-view</property>
     <property name="view_methods">
         <element value="@@simplelayout-view"/>
+        <element value="ftwcalendar_view"/>
     </property>
     <property name="default_view_fallback">False</property>
 


### PR DESCRIPTION
This PR together with PRs in `ftw.calendar` and `ftw.calendarexport` integrate `ftw.events` into the calendar.

`ftw.calendar`: https://github.com/4teamwork/ftw.calendar/pull/17
`ftw.calendarexport`: https://github.com/4teamwork/ftw.calendarexport/pull/5