### PR TITLE
Fix bug where default value was None instad of [].

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- Fixed bug where default value on eventlistingblock was not set. [lknoepfel]
+
 - Added ftw.calendar integration. [lknoepfel]
 
 - Don't list EventPage in the navigation [lkoepfel]

--- a/ftw/events/contents/eventlistingblock.py
+++ b/ftw/events/contents/eventlistingblock.py
@@ -48,6 +48,7 @@ class IEventListingBlockSchema(form.Schema):
             ),
         ),
         required=False,
+        default=[],
         missing_value=[],
     )
 
@@ -78,6 +79,7 @@ class IEventListingBlockSchema(form.Schema):
                               u'be shown.'),
         value_type=schema.Choice(vocabulary='ftw.events.vocabulary.subjects'),
         required=False,
+        default=[],
         missing_value=[],
     )
 


### PR DESCRIPTION
If i want to edit or delete a `EventListingBlock` plone throws an error because the values on the `filter_by_path` and `subjects` widgets are `None`.
It checks the value against the missing value of `[]`. `None != []` so it assumes it has a value. Tries to iterate over it and faceplants hard.

I couldn't reproduce this behaviour in a test. Not exactly sure why..