### PR TITLE
Fix AttributeError in create_event_listing_block

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix AttributeError in create_event_listing_block. [jone]
 
 
 1.0.0 (2016-08-02)

--- a/ftw/events/contents/eventfolder.py
+++ b/ftw/events/contents/eventfolder.py
@@ -1,10 +1,11 @@
-from zope.i18n import translate
 from ftw.events import _
 from ftw.events.interfaces import IEventFolder
 from plone import api
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.directives import form
+from zope.component.hooks import getSite
+from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
 
@@ -30,7 +31,7 @@ def create_event_listing_block(event_folder, event=None):
         type='ftw.events.EventListingBlock',
         title=translate(
             _(u'title_default_eventlisting_block', u'Events'),
-            context=event.newParent.REQUEST
+            context=getSite().REQUEST,
         ),
         current_context=True,
         subjects=[],


### PR DESCRIPTION
We have the signature
``create_event_listing_block(event_folder, event=None)``,
but when we pass no event we got an AttributeError.
By using ``getSite`` instead of ``event.newParent`` we can avoid this error.