### PR TITLE
Change German translation for event listing block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Change German translation for event listing block. [jone]
+
 - Fix AttributeError in create_event_listing_block. [jone]
 
 

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -29,7 +29,7 @@ msgstr "Veranstaltung"
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventListingBlock.xml
 msgid "EventListingBlock"
-msgstr "Veranstaltungen"
+msgstr "Auflistung von Veranstaltungen"
 
 #: ./ftw/events/profiles/default/actions.xml
 #: ./ftw/events/upgrades/20160915095729_add_ics_action/actions.xml
@@ -182,4 +182,3 @@ msgstr "Veranstaltungen"
 #: ./ftw/events/contents/eventfolder.py:32
 msgid "title_default_eventlisting_block"
 msgstr "Veranstaltungen"
-


### PR DESCRIPTION
The event listing block is not a set of events but only a listing of events, therefore the German translation "Veranstaltungen" is not accurate, "Auflistung von Veranstaltungen" is better.