### PR TITLE
Make EventFolder and EventListingBlock addable on the Plone Site by default.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make EventFolder and EventListingBlock addable on the Plone Site.
+  [lknoepfel]
 
 
 1.0.1 (2016-09-20)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,8 @@ Changelog
 
 - Fix AttributeError in create_event_listing_block. [jone]
 
+- Added action for ics export. [tschanzt]
+
 
 1.0.0 (2016-08-02)
 ------------------

--- a/ftw/events/profiles/default/types/Plone_Site.xml
+++ b/ftw/events/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.events.EventFolder" />
+        <element value="ftw.events.EventListingBlock" />
+    </property>
+
+</object>

--- a/ftw/events/upgrades/20160921161132_make_addable_on_plone_site/types/Plone_Site.xml
+++ b/ftw/events/upgrades/20160921161132_make_addable_on_plone_site/types/Plone_Site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.events.EventFolder" />
+        <element value="ftw.events.EventListingBlock" />
+    </property>
+
+</object>

--- a/ftw/events/upgrades/20160921161132_make_addable_on_plone_site/upgrade.py
+++ b/ftw/events/upgrades/20160921161132_make_addable_on_plone_site/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class MakeAddableOnPloneSite(UpgradeStep):
+    """Make addable on plone site.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Also add a missing changelog entry.

Fixes #12 and #13 

I didn't add an upgrade-step as this would change existing policy configuration.