### PR TITLE
Mopage support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 ftw.events
 ==============================================================================
 
+.. contents:: Table of Contents
+
 ``ftw.events`` is a Plone add-on allowing you to add containers (event folders)
 containing items representing an event (event page). It is backed by
 ``plone.app.event`` and is powered by ``ftw.simplelayout``.
@@ -29,6 +31,58 @@ Usage
 
 Start by creating a container which will hold the events by adding a *event folder*.
 Add as many *event pages* to the event folder as you like.
+
+
+Mopage Support
+--------------
+
+``ftw.events`` provides integration for the mopage mobile app
+(http://web.anthrazit.org/).
+
+
+Data Endpoint
+~~~~~~~~~~~~~
+
+The view ``mopage.events.xml`` returns an XML-feed with the latest events within
+the context it is called. It can becalled on any type of object.
+
+- The mopage-API expects a ``partnerid`` and a ``importid``.
+  They are incldued when submitted via GET-parameter, e.g.:
+  ``http://foo.com/events/mopage.events.xml?partnerid=123&importid=456``
+
+- The endpoint returns only 100 events by default.
+  This can be changed with the parameter ``?per_page=200``.
+
+- The endpoint returns ``Link``-headers in the response with pagination links.
+
+
+Trigger behavior
+~~~~~~~~~~~~~~~~
+
+The behavior ``ftw.events.behaviors.mopage.IPublisherMopageTrigger`` can be added
+on a event folder in order to configure automatic notification to the mopage API
+that new events are published.
+
+In order for the behavior to work properly you need an ``ftw.publisher`` setup.
+Only the receiver-side (public website) will trigger the notification.
+A configured ``collective.taskqueue`` is required for this to work.
+
+Buildout example:
+
+.. code:: ini
+
+    [instance]
+    eggs +=
+        ftw.events[mopage_publisher_receiver]
+
+    zope-conf-additional +=
+        %import collective.taskqueue
+        <taskqueue />
+        <taskqueue-server />
+
+
+Then enable the behavior for the event folder type and configure the trigger
+with the newly availabe fields.
 
 
 Background

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Implement mopage support. [jone]
+
 - Split up location into structured fields title, street, ZIP and city. [jone]
 
 

--- a/ftw/events/behaviors/configure.zcml
+++ b/ftw/events/behaviors/configure.zcml
@@ -14,4 +14,41 @@
         for="ftw.events.interfaces.IEventPage"
         />
 
+    <plone:behavior
+        title="Mopage trigger configuration"
+        description="Provides fields for configuring a mopage trigger (ftw.publisher)."
+        provides="ftw.events.behaviors.mopage.IPublisherMopageTrigger"
+        for="ftw.events.interfaces.IEventFolder"
+        marker="ftw.events.behaviors.mopage.IPublisherMopageTriggerSupport"
+        factory="ftw.events.behaviors.mopage.PublisherMopageTrigger"
+        />
+
+    <configure zcml:condition="have ftw.events:mopage_publisher_receiver">
+
+        <subscriber
+            for="*
+                 ftw.publisher.receiver.interfaces.IAfterCreatedEvent"
+            handler=".mopage.trigger_mopage_refresh" />
+
+        <subscriber
+            for="*
+                 ftw.publisher.receiver.interfaces.IAfterUpdatedEvent"
+            handler=".mopage.trigger_mopage_refresh" />
+
+        <browser:page
+            name="taskqueue_events_trigger_mopage_refresh"
+            for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
+            layer="collective.taskqueue.interfaces.ITaskQueueLayer"
+            class=".mopage.TriggerMopageRefreshTaskQueueWorker"
+            permission="zope2.View"
+            />
+
+        <adapter
+            for="ftw.events.interfaces.IEventPage"
+            provides="ftw.events.behaviors.mopage.IMopageModificationDate"
+            factory="ftw.events.behaviors.mopage.MopageModificationDate"
+            />
+
+    </configure>
+
 </configure>

--- a/ftw/events/behaviors/mopage.py
+++ b/ftw/events/behaviors/mopage.py
@@ -1,0 +1,183 @@
+from Acquisition import aq_chain
+from DateTime import DateTime
+from ftw.events import _
+from ftw.events.interfaces import IEventPage
+from plone.app.dexterity.behaviors.metadata import DCFieldProperty
+from plone.app.dexterity.behaviors.metadata import MetadataBase
+from plone.autoform.directives import read_permission
+from plone.autoform.directives import write_permission
+from plone.directives.form import fieldset
+from plone.directives.form import IFormFieldProvider
+from plone.directives.form import Schema
+from Products.Five.browser import BrowserView
+from zope import schema
+from zope.annotation import IAnnotations
+from zope.component.hooks import getSite
+from zope.interface import alsoProvides
+from zope.interface import implements
+from zope.interface import Interface
+import requests
+import urllib
+import urlparse
+
+
+class IPublisherMopageTrigger(Schema):
+
+    fieldset('mopage',
+             label=_(u'Mopage'),
+             fields=['mopage_enabled',
+                     'mopage_trigger_url',
+                     'mopage_data_endpoint_url'])
+
+    read_permission(mopage_enabled='ftw.events.ConfigureMopageTrigger')
+    write_permission(mopage_enabled='ftw.events.ConfigureMopageTrigger')
+    mopage_enabled = schema.Bool(
+        title=_(u'label_trigger_enabled',
+                default=u'Mopage trigger enabled'),
+        default=False,
+        required=False,
+    )
+
+    read_permission(mopage_trigger_url='ftw.events.ConfigureMopageTrigger')
+    write_permission(mopage_trigger_url='ftw.events.ConfigureMopageTrigger')
+    mopage_trigger_url = schema.URI(
+        title=_(u'label_mopage_trigger_url',
+                default=u'Mopage trigger URL'),
+        description=_(
+            u'description_mopage_trigger_url',
+            default=u'Contains the mopage URL to the trigger endpoint.'
+            u' This is only the base URL, it does not contain the endpoint URL'
+            u' from which the mopage server retrieves the events.'
+            u' Example: https://un:pw@xml.mopage.ch/infoservice/xml.php'
+        ),
+        default=None,
+        required=False,
+    )
+
+    read_permission(
+        mopage_data_endpoint_url='ftw.events.ConfigureMopageTrigger')
+    write_permission(
+        mopage_data_endpoint_url='ftw.events.ConfigureMopageTrigger')
+    mopage_data_endpoint_url = schema.URI(
+        title=_(u'label_mopage_data_endpoint_url',
+                default=u'Mopage data endpoint URL (Plone)'),
+        description=_(
+            u'description_mopage_data_endpoint_url',
+            default=u'The mopage data endpoint URL points to the'
+            u' "mopage.events.xml" view somewhere on the public visible '
+            u' Plone page. It must also contain the params "partnerid"'
+            u' and "importid".'
+            u' Example: https://mypage.ch/events/'
+            u'mopage.events.xml?partnerid=3&importid=6'
+        ),
+        default=None,
+        required=False,
+    )
+
+
+alsoProvides(IPublisherMopageTrigger, IFormFieldProvider)
+
+
+class IPublisherMopageTriggerSupport(Interface):
+    """Marker interface for event folders which support IPublisherMopageTrigger.
+    """
+
+
+class PublisherMopageTrigger(MetadataBase):
+    """Behavior adapter for IPublisherMopageTrigger.
+    The storage is the adapted context.
+    """
+
+    mopage_enabled = DCFieldProperty(
+        IPublisherMopageTrigger['mopage_enabled'])
+    mopage_trigger_url = DCFieldProperty(
+        IPublisherMopageTrigger['mopage_trigger_url'])
+    mopage_data_endpoint_url = DCFieldProperty(
+        IPublisherMopageTrigger['mopage_data_endpoint_url'])
+
+    def is_enabled(self):
+        return self.mopage_enabled \
+            and self.mopage_trigger_url \
+            and self.mopage_data_endpoint_url
+
+    def build_trigger_url(self):
+        if not self.is_enabled():
+            return None
+
+        parts = list(urlparse.urlparse(self.mopage_trigger_url))
+        parts[5] = ''  # drop anchor
+        parts[4] = urllib.urlencode({'url': self.mopage_data_endpoint_url})
+        return urlparse.urlunparse(parts)
+
+
+class IMopageModificationDate(Interface):
+    """The modification date adapter stores and provides a mopage
+    specific modification date which is used for tracking content changes
+    of an event page.
+    This is important in order to tell the Mopage system that something has
+    changed.
+    """
+
+    def get_date():
+        """Return the current modification date.
+        """
+
+    def set_date(date):
+        """Set modification date to a speicifc date.
+        """
+
+    def touch():
+        """Set modification date to now.
+        """
+
+
+class MopageModificationDate(object):
+    implements(IMopageModificationDate)
+
+    annotations_key = 'ftw.events:mopage:modification_date'
+
+    def __init__(self, context):
+        self.context = context
+
+    def get_date(self):
+        date = IAnnotations(self.context).get(self.annotations_key, None)
+        return date or self.context.modified()
+
+    def set_date(self, date):
+        IAnnotations(self.context)[self.annotations_key] = DateTime(date)
+
+    def touch(self):
+        self.set_date(DateTime())
+
+
+def trigger_mopage_refresh(obj, event):
+    event_pages = filter(None,
+                          map(lambda parent: IEventPage(parent, None),
+                              aq_chain(obj)))
+    if not event_pages:
+        # We are not within an event page.
+        # We only trigger when publishing an event page
+        # or a child of an event page.
+        return
+
+    triggers = filter(None,
+                      map(lambda parent: IPublisherMopageTrigger(parent, None),
+                          aq_chain(obj)))
+    if not triggers or not triggers[0].is_enabled():
+        return
+
+    for events in event_pages:
+        IMopageModificationDate(events).touch()
+
+    from collective.taskqueue import taskqueue
+
+    trigger_url = triggers[0].build_trigger_url()
+    callback_path = '/'.join(getSite().getPhysicalPath()
+                             + ('taskqueue_events_trigger_mopage_refresh',))
+    taskqueue.add(callback_path, params={'target': trigger_url})
+
+
+class TriggerMopageRefreshTaskQueueWorker(BrowserView):
+
+    def __call__(self):
+        requests.get(self.request.form['target']).raise_for_status()

--- a/ftw/events/browser/configure.zcml
+++ b/ftw/events/browser/configure.zcml
@@ -18,4 +18,12 @@
         permission="zope2.View"
         />
 
+    <browser:page
+        for="*"
+        name="mopage.events.xml"
+        class=".mopage.MopageEvents"
+        template="templates/mopage_events.pt"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/ftw/events/browser/mopage.py
+++ b/ftw/events/browser/mopage.py
@@ -1,0 +1,234 @@
+from DateTime import DateTime
+from ftw.events.behaviors.location import ILocationFields
+from ftw.events.behaviors.mopage import IMopageModificationDate
+from htmlentitydefs import name2codepoint as n2cp
+from plone.app.dexterity.behaviors.metadata import ICategorization
+from plone.event.interfaces import IRecurrenceSupport
+from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from zExceptions import BadRequest
+import lxml.html
+import math
+import re
+import urllib
+import urlparse
+
+
+def normalize_whitespace(text, replacement=' '):
+    text = re.sub(r'^\s+', replacement, text)
+    text = re.sub(r'\s+$', replacement, text)
+    return text
+
+
+def normalize_join(*parts):
+    return normalize_whitespace(''.join([part or '' for part in parts]))
+
+
+def remove_node(node):
+    parent = node.getparent()
+    if parent is None:
+        return
+
+    position = parent.index(node)
+
+    if position == 0:
+        parent.text = normalize_join(parent.text, node.tail)
+    else:
+        sibling = parent[position - 1]
+        sibling.tail = normalize_join(sibling.tail, node.tail)
+
+    parent.remove(node)
+
+
+def crop(length, text):
+    if not text:
+        return text
+
+    if isinstance(text, str):
+        text = text.decode('utf-8')
+    if len(text) > length:
+        text = text[:length - 5] + ' ...'
+
+    return text
+
+
+def decode_entities(text):
+    """
+    Decodes html entities and xml entities.
+    """
+    entity_re = re.compile("&(#?)(\d{1,5}|\w{1,8});")
+
+    def substitute_entity(match):
+        ent = match.group(2)
+        if match.group(1) == "#":
+            return unichr(int(ent))
+
+        else:
+            cp = n2cp.get(ent)
+            if cp:
+                return unichr(cp)
+            else:
+                return match.group()
+
+    return entity_re.subn(substitute_entity, text)[0]
+
+
+class MopageEvents(BrowserView):
+    """Documentation: http://doc.mopage.ch/ext/XML_Schnittstelle/2_XML_Aufbau
+    """
+
+    def __call__(self):
+        self.request.RESPONSE.setHeader('Cache-Control', 'no-store')
+        self.request.RESPONSE.setHeader('Content-Type',
+                                        'text/xml;charset=utf-8')
+        return super(MopageEvents, self).__call__()
+
+    def import_node_attributes(self):
+        attrs = {'export_time': self.normalize_date(DateTime())}
+        for name in ('partner', 'partnerid', 'passwort', 'importid',
+                     'vaterobjekt'):
+            attrs[name] = self.request.form.get(name, None)
+        return attrs
+
+    def items(self):
+        brains = self.apply_pagination(self.get_brains())
+        return map(self.brain_to_item, brains)
+
+    def get_brains(self):
+        catalog = getToolByName(self.context, 'portal_catalog')
+        return catalog(self.get_query())
+
+    def apply_pagination(self, brains):
+        per_page = self.get_int_param_from_request('per_page', 100)
+        page = self.get_int_param_from_request('page', 1)
+        last = page * per_page
+        first = last - per_page
+        batch = brains[first:last]
+
+        links = []
+        if page > 1:
+            links.append(self.build_pagination_link('first', page=1))
+            links.append(self.build_pagination_link('prev', page=page - 1))
+
+        if len(brains) > last:
+            links.append(self.build_pagination_link('next',
+                                                    page=int(page + 1)))
+            links.append(self.build_pagination_link(
+                'last', page=int(math.ceil(len(brains) / float(per_page)))))
+
+        if links:
+            self.request.RESPONSE.setHeader('Link', ','.join(links))
+
+        return batch
+
+    def get_query(self):
+        return {
+            'object_provides': 'ftw.events.interfaces.IEventPage',
+            'sort_on': 'start',
+            'sort_order': 'reverse',
+            'path': '/'.join(self.context.getPhysicalPath())}
+
+    def brain_to_item(self, brain):
+        obj = brain.getObject()
+        image_url = self.get_lead_image_url(obj)
+
+        if image_url and len(image_url) > 255:
+            # sorry, not supported.
+            image_url = None
+
+        textlead = crop(100, obj.Description() or '')
+        if textlead:
+            textlead = u'<![CDATA[{}]]>'.format(textlead)
+
+        subjects = getattr(ICategorization(obj, None), 'subjects', ())
+        modified_date = IMopageModificationDate(obj).get_date()
+        occurences = IRecurrenceSupport(obj).occurrences()
+
+        location = {}
+        if ILocationFields.providedBy(obj):
+            storage = ILocationFields(obj)
+            # All fields wich are "required" by the API must have a value
+            # in order to have a location.
+            if storage.location_title \
+               and storage.location_street \
+               and storage.location_zip \
+               and storage.location_city:
+                location.update({
+                    'title': storage.location_title,
+                    'street': storage.location_street,
+                    'zip': storage.location_zip,
+                    'city': storage.location_city,
+                })
+
+        return {'title': crop(100, brain.Title),
+                'modified_date': self.normalize_date(modified_date),
+                'occurences': occurences,
+                'uid': IUUID(obj),
+                'url': brain.getURL(),
+                'textlead': textlead,
+                'image_url': image_url,
+                'subjects': map(lambda subject: crop(100, subject), subjects),
+                'location': location,
+                'obj': obj}
+
+    def normalize_date(self, date):
+        if not date:
+            return ''
+
+        if DateTime(date) > DateTime(2100, 1, 1):
+            return None
+
+        return date.strftime('%Y-%m-%d %H:%M:%S')
+
+    def cleanup_body_html(self, html):
+        """We have HTML with simplelayout structure, but this is too noisy
+        for the import.
+        We therefore convert the HTML to text and back to HTML.
+        We also need to make sure that the result is less than 10000 long.
+        """
+
+        doc = lxml.html.fromstring(html)
+        map(remove_node, doc.xpath(
+            '//*[contains(concat(" ", normalize-space(@class), " "), '
+            '" hiddenStructure ")]'))
+        html = lxml.etree.tostring(doc, pretty_print=True)
+
+        portal_transforms = getToolByName(self.context, 'portal_transforms')
+        text = decode_entities(portal_transforms.convertToData(
+            'text/x-web-intelligent',
+            html,
+            mimetype='text/html').strip())
+
+        # body limit is 10000.
+        # We have text here, but will convert it to HTML, so it will be larger
+        # and we need to crop more to compensate.
+        for attempt in range(100):
+            text = crop(10000 - (len(text) * 0.1), text)
+            html = portal_transforms.convertToData(
+                'text/html',
+                text,
+                mimetype='text/x-web-intelligent').strip()
+
+            if len(html) < 10000:
+                return u'<![CDATA[' + html + u']]>'
+
+        return u'<![CDATA[cropping error]]>'
+
+    def get_lead_image_url(self, events):
+        scale = events.restrictedTraverse('@@leadimage').get_scale()
+        return scale and scale.url or None
+
+    def get_int_param_from_request(self, name, default):
+        value = int(self.request.get(name, default))
+        if value < 1:
+            raise BadRequest('Invalid "{}" parameter value.'.format(name))
+        return value
+
+    def build_pagination_link(self, rel, **kwargs):
+        params = self.request.form.copy()
+        params.update(kwargs)
+        parts = list(urlparse.urlparse(self.request.ACTUAL_URL))
+        parts[4] = urllib.urlencode(params)
+        url = urlparse.urlunparse(parts)
+        return '<{}>; rel="{}"'.format(url, rel)

--- a/ftw/events/browser/templates/mopage_events.pt
+++ b/ftw/events/browser/templates/mopage_events.pt
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<import xmlns:tal="http://xml.zope.org/namespaces/tal"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.events"
+        tal:define="attrs view/import_node_attributes"
+        tal:attributes="export_time attrs/export_time;
+                        partner attrs/partner;
+                        partnerid attrs/partnerid;
+                        passwort attrs/passwort;
+                        importid attrs/importid;
+                        vaterobjekt attrs/vaterobjekt">
+
+    <item tal:repeat="item view/items"
+          tal:attributes="mutationsdatum item/modified_date"
+          status="1"
+          suchbar="1">
+        <id tal:content="item/uid" />
+        <titel tal:content="item/title" />
+        <termin tal:repeat="occurence item/occurences"
+                tal:attributes="allday python:occurence.whole_day and 1 or None">
+            <von tal:content="python:view.normalize_date(occurence.start)" />
+            <bis tal:content="python:view.normalize_date(occurence.end)" />
+        </termin>
+        <textlead tal:content="structure item/textlead" />
+        <url_bild tal:content="item/image_url" tal:condition="item/image_url" />
+        <textmobile tal:define="context nocall:item/obj;
+                                html simplelayout:default">
+            <tal:TEXT replace="structure python:view.cleanup_body_html(html)" />
+        </textmobile>
+        <rubrik tal:repeat="subject item/subjects"
+                tal:content="subject" />
+        <veranstaltungsort tal:condition="item/location">
+            <titel tal:content="item/location/title" />
+            <adresse tal:content="item/location/street" />
+            <plz tal:content="item/location/zip" />
+            <ort tal:content="item/location/city" />
+        </veranstaltungsort>
+    </item>
+
+</import>

--- a/ftw/events/configure.zcml
+++ b/ftw/events/configure.zcml
@@ -1,9 +1,13 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:autofeature="http://namespaces.zope.org/autofeature"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="ftw.events">
+
+    <include package="ftw.autofeature" file="meta.zcml" />
+    <autofeature:extras />
 
     <i18n:registerTranslations directory="locales" />
 

--- a/ftw/events/lawgiver.zcml
+++ b/ftw/events/lawgiver.zcml
@@ -20,4 +20,9 @@
         permissions="ftw.events: Add EventListingBlock"
         />
 
+    <lawgiver:map_permissions
+        action_group="manage content settings"
+        permissions="ftw.events: Configure mopage trigger"
+        />
+
 </configure>

--- a/ftw/events/permissions.zcml
+++ b/ftw/events/permissions.zcml
@@ -17,4 +17,9 @@
         title="ftw.events: Add EventListingBlock"
         />
 
+    <permission
+        id="ftw.events.ConfigureMopageTrigger"
+        title="ftw.events: Configure mopage trigger"
+        />
+
 </configure>

--- a/ftw/events/testing.py
+++ b/ftw/events/testing.py
@@ -1,3 +1,5 @@
+from collective.taskqueue.testing import TASK_QUEUE_ZSERVER_FIXTURE
+from collective.taskqueue.testing import ZSERVER_FIXTURE
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
@@ -48,3 +50,34 @@ FUNCTIONAL_ZSERVER_TESTING = FunctionalTesting(
     bases=(EVENTS_ZSERVER_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="ftw.events:zserverfunctional")
+
+
+class MopageTriggerLayer(EventsLayer):
+
+    def setUpZope(self, app, configurationContext):
+        super(MopageTriggerLayer, self).setUpZope(app, configurationContext)
+        xmlconfig.string(
+            '''
+            <configure xmlns="http://namespaces.zope.org/zope"
+                       xmlns:browser="http://namespaces.zope.org/browser">
+
+                <browser:page
+                    for="*"
+                    name="mopage-stub"
+                    class="ftw.events.tests.test_mopage_trigger.MopageAPIStub"
+                    permission="zope2.View"
+                    />
+
+            </configure>''',
+            context=configurationContext)
+
+
+MOPAGE_TRIGGER_FIXTURE = MopageTriggerLayer()
+
+
+MOPAGE_TRIGGER_FUNCTIONAL = FunctionalTesting(
+    bases=(ZSERVER_FIXTURE,
+           TASK_QUEUE_ZSERVER_FIXTURE,
+           MOPAGE_TRIGGER_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="ftw.events:functional:taskqueue")

--- a/ftw/events/tests/__init__.py
+++ b/ftw/events/tests/__init__.py
@@ -1,7 +1,9 @@
 from ftw.events.testing import FUNCTIONAL_TESTING
 from ftw.events.testing import FUNCTIONAL_ZSERVER_TESTING
+from lxml import etree
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from StringIO import StringIO
 from unittest2 import TestCase
 import transaction
 
@@ -19,3 +21,37 @@ class FunctionalTestCase(TestCase):
 
 class RealFuncitionalTestCase(FunctionalTestCase):
     layer = FUNCTIONAL_ZSERVER_TESTING
+
+
+class XMLDiffTestCase(TestCase):
+
+    def _canonicalize_xml(self, text, node_sorter=None):
+        parser = etree.XMLParser(remove_blank_text=True)
+        try:
+            xml = etree.fromstring(text, parser)
+        except etree.XMLSyntaxError, exc:
+            print '-' * 10
+            print exc.error_log
+            print '-' * 10
+            print text
+            print '-' * 10
+            raise
+
+        norm = StringIO()
+        if node_sorter:
+            # Search for parent elements
+            for parent in xml.xpath('//*[./*]'):
+                parent[:] = sorted(parent, node_sorter)
+
+        xml.getroottree().write_c14n(norm)
+        xml = etree.fromstring(norm.getvalue())
+        return etree.tostring(xml.getroottree(),
+                              pretty_print=True,
+                              xml_declaration=True,
+                              encoding='utf-8')
+
+    def assert_xml(self, xml1, xml2):
+        norm1 = self._canonicalize_xml(xml1)
+        norm2 = self._canonicalize_xml(xml2)
+        self.maxDiff = None
+        self.assertMultiLineEqual(norm1, norm2)

--- a/ftw/events/tests/mopage_assets/lorem1.html
+++ b/ftw/events/tests/mopage_assets/lorem1.html
@@ -1,0 +1,2 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sapientem locupletat ipsa natura, cuius divitias <b>Epicurus</b> parabiles esse docuit. Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis.</p>
+<p>Lorem ipsum dolor sit amet, consectetur "adipiscing" elit. At certe gravius. Ut optime, secundum naturam «affectum» esse possit. Quia dölori non voluptas contraria est, sed doloris privatio. Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis. Sed nunc, quod agimus; Duo Reges: constructio interrete.</p>

--- a/ftw/events/tests/mopage_assets/mopage.events.xml
+++ b/ftw/events/tests/mopage_assets/mopage.events.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="iso-8859-15" ?>
+<import export_time="2011-01-02 04:04:00">
+
+    <item status="1" suchbar="1" mutationsdatum="2010-03-15 00:00:00">
+        <id>uid00000000000000000000000000003</id>
+        <titel>Wanderausstellung Kaffeebohnen</titel>
+        <termin>
+            <von>2010-10-07 09:00:00</von>
+            <bis>2010-10-07 16:00:00</bis>
+        </termin>
+        <termin>
+            <von>2010-10-08 09:00:00</von>
+            <bis>2010-10-08 16:00:00</bis>
+        </termin>
+        <termin>
+            <von>2010-10-09 09:00:00</von>
+            <bis>2010-10-09 16:00:00</bis>
+        </termin>
+        <termin>
+            <von>2010-10-10 09:00:00</von>
+            <bis>2010-10-10 16:00:00</bis>
+        </termin>
+        <textlead><![CDATA[Die Wanderausstellung Kaffeebohnen beschäftigt sich mit allen möglichen Kaffeesorten aus aller Welt.]]></textlead>
+        <url_bild>http://nohost/plone/event-folder/wanderausstellung-kaffeebohnen/ftw-simplelayout-textblock/image.jpg</url_bild>
+        <textmobile>
+            <![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sapientem locupletat ipsa natura, cuius divitias Epicurus parabiles esse docuit. Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis.<br /><br />&nbsp;Lorem ipsum dolor sit amet, consectetur &quot;adipiscing&quot; elit. At certe gravius. Ut optime, secundum naturam &laquo;affectum&raquo; esse possit. Quia d&ouml;lori non voluptas contraria est, sed doloris privatio. Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis. Sed nunc, quod agimus; Duo Reges: constructio interrete.]]>
+        </textmobile>
+        <rubrik>Kaffee</rubrik>
+        <rubrik>Wanderausstellung</rubrik>
+        <veranstaltungsort>
+            <titel>Kunstmuseum Bern</titel>
+            <adresse>Hodlerstrasse 8</adresse>
+            <plz>3011</plz>
+            <ort>Bern</ort>
+        </veranstaltungsort>
+    </item>
+
+    <item status="1" suchbar="1" mutationsdatum="2010-05-17 17:34:00">
+        <id>uid00000000000000000000000000005</id>
+        <titel>Bratwurstgrillieren</titel>
+        <termin allday="1">
+            <von>2010-05-18 00:00:00</von>
+            <bis>2010-05-18 23:59:59</bis>
+        </termin>
+        <textlead></textlead>
+
+        <textmobile>
+            <![CDATA[]]>
+        </textmobile>
+    </item>
+
+</import>

--- a/ftw/events/tests/test_mopage_export.py
+++ b/ftw/events/tests/test_mopage_export.py
@@ -1,0 +1,188 @@
+from datetime import datetime
+from DateTime import DateTime
+from datetime import timedelta
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.events.behaviors.mopage import IMopageModificationDate
+from ftw.events.tests import FunctionalTestCase
+from ftw.events.tests import utils
+from ftw.events.tests import XMLDiffTestCase
+from ftw.testbrowser import browser
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from ftw.testing import staticuid
+from path import Path
+from plone.app.textfield import RichTextValue
+from pytz import timezone
+import re
+
+
+ZURICH = timezone('Europe/Zurich')
+
+
+class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
+
+    @staticuid('uid')
+    @browsing
+    def test_01_export_events(self, browser):
+        self.grant('Manager')
+        event_folder = create(Builder('event folder').titled(u'event folder'))
+
+        with freeze(datetime(2010, 3, 14, 20, 18, tzinfo=ZURICH)):
+            events1 = create(
+                Builder('event page')
+                .titled(u'Wanderausstellung Kaffeebohnen')
+                .within(event_folder)
+                .starting(datetime(2010, 10, 7, 9, 00))
+                .ending(datetime(2010, 10, 7, 16, 00))
+                .having(recurrence='RRULE:FREQ=DAILY;COUNT=4',
+                        description=u'Die Wanderausstellung Kaffeebohnen'
+                        u' besch\xe4ftigt sich mit allen m\xf6glichen'
+                        u' Kaffeesorten aus aller Welt.',
+                        subjects=('Kaffee', 'Wanderausstellung'),
+                        location_title='Kunstmuseum Bern',
+                        location_street='Hodlerstrasse 8',
+                        location_zip=3011,
+                        location_city='Bern'))
+
+            lorem = RichTextValue(self.asset('lorem1.html'))
+            block = create(Builder('sl textblock').within(events1)
+                           .with_dummy_image()
+                           .having(text=lorem))
+            utils.create_page_state(events1, block)
+            IMopageModificationDate(events1).set_date(DateTime('2010/3/15'))
+
+        with freeze(datetime(2010, 5, 17, 15, 34, tzinfo=ZURICH)):
+            create(Builder('event page')
+                   .titled(u'Bratwurstgrillieren')
+                   .within(event_folder)
+                   .starting(datetime(2010, 5, 18))
+                   .ending(datetime(2010, 5, 18))
+                   .having(whole_day=True,
+                           # Location is incomplete and will not appear.
+                           location_title='Kunstmuseum Bern'))
+
+        with freeze(datetime(2011, 1, 2, 3, 4, tzinfo=ZURICH)):
+            self.assert_mopage_export('mopage.events.xml', event_folder)
+
+    @browsing
+    def test_pagination(self, browser):
+        self.grant('Manager')
+        event_folder = create(Builder('event folder').titled(u'Events'))
+        with freeze(datetime(2015, 10, 1, 14, 0, tzinfo=ZURICH)) as clock:
+            create(Builder('event page').titled(u'One').within(event_folder)
+                   .starting(datetime.now() + timedelta(hours=2))
+                   .ending(datetime.now() + timedelta(hours=2)))
+            clock.forward(days=1)
+            create(Builder('event page').titled(u'Two').within(event_folder)
+                   .starting(datetime.now() + timedelta(hours=2))
+                   .ending(datetime.now() + timedelta(hours=2)))
+            clock.forward(days=1)
+            create(Builder('event page').titled(u'Three').within(event_folder)
+                   .starting(datetime.now() + timedelta(hours=2))
+                   .ending(datetime.now() + timedelta(hours=2)))
+            clock.forward(days=1)
+            create(Builder('event page').titled(u'Four').within(event_folder)
+                   .starting(datetime.now() + timedelta(hours=2))
+                   .ending(datetime.now() + timedelta(hours=2)))
+            clock.forward(days=1)
+            create(Builder('event page').titled(u'Five').within(event_folder)
+                   .starting(datetime.now() + timedelta(hours=2))
+                   .ending(datetime.now() + timedelta(hours=2)))
+
+        browser.open(event_folder, view='mopage.events.xml?per_page=2')
+        self.assert_events_in_browser(['Five', 'Four'])
+        links = self.get_links_from_response()
+        self.assertEquals(
+            {'next': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=2',
+             'last': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=3'},
+            links)
+
+        browser.open(links['next'])
+        self.assert_events_in_browser(['Three', 'Two'])
+        links = self.get_links_from_response()
+        self.assertEquals(
+            {'first': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=1',
+             'prev': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=1',
+             'next': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=3',
+             'last': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=3'},
+            links)
+
+        browser.open(links['next'])
+        self.assert_events_in_browser(['One'])
+        links = self.get_links_from_response()
+        self.assertEquals(
+            {'first': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=1',
+             'prev': 'http://nohost/plone/events/mopage.events.xml?per_page=2&page=2'},
+            links)
+
+    @browsing
+    def test_export_all_events_on_site(self, browser):
+        self.grant('Manager')
+        create(Builder('event page').titled(u'One').within(
+            create(Builder('event folder').titled(u'Event Folder One'))))
+        create(Builder('event page').titled(u'Two').within(
+            create(Builder('event folder').titled(u'Event Folder Two'))))
+
+        browser.open(self.portal, view='mopage.events.xml')
+        self.assert_events_in_browser(['One', 'Two'])
+
+    @browsing
+    def test_title_is_cropped(self, browser):
+        self.grant('Manager')
+        create(Builder('event page').titled(u'A' * 150).within(
+            create(Builder('event folder'))))
+
+        browser.open(self.portal, view='mopage.events.xml')
+        self.assert_events_in_browser(['A' * 95 + ' ...'])
+
+    @browsing
+    def test_include_root_arguments_when_submitted_as_GET_param(self, browser):
+        self.grant('Manager')
+        create(Builder('event page').within(create(Builder('event folder'))))
+
+        with freeze(datetime(2016, 8, 9, 21, 45, tzinfo=ZURICH)):
+            browser.open(self.portal, view='mopage.events.xml',
+                         data={'partner': 'Partner',
+                               'partnerid': '123',
+                               'passwort': 's3c>r3t',
+                               'importid': '456',
+                               'vaterobjekt': 'xy',
+                               'unkown_key': 'should not appear'})
+
+        self.assertEquals(
+            {
+                'export_time': '2016-08-09 23:45:00',
+                'partner': 'Partner',
+                'partnerid': '123',
+                'passwort': 's3c>r3t',
+                'importid': '456',
+                'vaterobjekt': 'xy',
+            },
+            browser.css('import').first.attrib)
+
+    def assert_mopage_export(self, asset_name, export_context):
+        expected = self.asset(asset_name)
+        browser.open(export_context, view='mopage.events.xml')
+        got = browser.contents
+        # replace dynamic scale image urls for having static test results:
+        got = re.sub(r'\/@@images/[a-z0-9-]{36}.jpeg', '/image.jpg', got)
+        # remove trailing spaces:
+        got = re.sub(r' +$', '', got, flags=re.M)
+        self.maxDiff = None
+        self.assert_xml(expected, got)
+
+    def asset(self, asset_name):
+        assets = Path(__file__).joinpath('..', 'mopage_assets').abspath()
+        return assets.joinpath(asset_name).bytes()
+
+    def assert_events_in_browser(self, expected_titles):
+        got_titles = browser.css('titel').text
+        self.assertEquals(expected_titles, got_titles)
+
+    def get_links_from_response(self):
+        def parse_link(text):
+            return tuple(reversed(re.match(
+                r'^<([^>]+)>; rel="([^"]+)"', text).groups()))
+
+        return dict(map(parse_link, browser.headers.get('Link').split(',')))

--- a/ftw/events/tests/test_mopage_trigger.py
+++ b/ftw/events/tests/test_mopage_trigger.py
@@ -1,0 +1,194 @@
+from collective.taskqueue.testing import runAsyncTest
+from DateTime import DateTime
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.events.behaviors.mopage import IMopageModificationDate
+from ftw.events.behaviors.mopage import IPublisherMopageTrigger
+from ftw.events.testing import MOPAGE_TRIGGER_FUNCTIONAL
+from ftw.events.tests import FunctionalTestCase
+from ftw.publisher.receiver.events import AfterCreatedEvent
+from ftw.publisher.receiver.events import AfterUpdatedEvent
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
+from ftw.testing import freeze
+from persistent.list import PersistentList
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from pytz import timezone
+from zope.annotation.interfaces import IAnnotations
+from zope.event import notify
+import transaction
+import urlparse
+
+
+def get_stub_log(portal):
+    annotations = IAnnotations(portal)
+    key = 'ftw.events-mopage-stub-log'
+    if key not in annotations:
+        annotations[key] = PersistentList()
+    return annotations[key]
+
+
+class MopageAPIStub(BrowserView):
+
+    def __call__(self):
+        log = get_stub_log(self.context)
+        log.append(self.request.form)
+        return 'OK'
+
+
+class TestMopageTrigger(FunctionalTestCase):
+    layer = MOPAGE_TRIGGER_FUNCTIONAL
+
+    def setUp(self):
+        super(TestMopageTrigger, self).setUp()
+        portal_types = getToolByName(self.portal, 'portal_types')
+        portal_types['ftw.events.EventFolder'].behaviors += (
+            'ftw.events.behaviors.mopage.IPublisherMopageTrigger',
+        )
+        transaction.commit()
+
+    @browsing
+    def test_configure_trigger_on_event_folder(self, browser):
+        self.grant('Manager')
+        browser.login().open()
+        factoriesmenu.add('Event Folder')
+        browser.fill(
+            {'Title': 'Event Folder',
+             'Mopage trigger enabled': True,
+             'Mopage trigger URL': (
+                 'https://un:pw@xml.mopage.ch/infoservice/xml.php'),
+             'Mopage data endpoint URL (Plone)': (
+                 'http://nohost/plone/event-folder/mopage.events.xml'
+                 '?partnerid=123&imported=456')}).save()
+
+        statusmessages.assert_no_error_messages()
+
+        mopage_trigger = IPublisherMopageTrigger(browser.context)
+        self.assertTrue(mopage_trigger.is_enabled())
+
+        trigger_url = mopage_trigger.build_trigger_url()
+        self.assertEquals('https://un:pw@xml.mopage.ch/infoservice/xml.php'
+                          '?url=http%3A%2F%2Fnohost%2Fplone%2Fevent-folder'
+                          '%2Fmopage.events.xml%3Fpartnerid%3D123%26imported%3D456',
+                          trigger_url)
+
+        params =  urlparse.parse_qs(urlparse.urlparse(trigger_url)[4])['url']
+        self.assertEquals(['http://nohost/plone/event-folder/'
+                           'mopage.events.xml?partnerid=123&imported=456'],
+                          params)
+
+    def test_trigger_notified_when_events_created(self):
+        self.grant('Manager')
+        trigger_url = self.portal.portal_url() + '/mopage-stub'
+        endpoint_url = (self.portal.portal_url() + '/event-folder/mopage.events.xml' +
+                        '?partnerid=213&importid=456')
+
+        folder = create(Builder('event folder')
+                        .titled(u'Event Folder')
+                        .having(mopage_enabled=True,
+                                mopage_trigger_url=trigger_url,
+                                mopage_data_endpoint_url=endpoint_url))
+
+        events = create(Builder('event page').titled(u'The Events').within(folder))
+        self.assertEquals([], get_stub_log(self.portal))
+
+        notify(AfterCreatedEvent(events))
+        transaction.commit()
+        runAsyncTest(lambda: None)
+        transaction.begin()
+        self.assertEquals(
+            [{'url': endpoint_url}],
+            get_stub_log(self.portal))
+
+    def test_trigger_notified_when_events_updated(self):
+        self.grant('Manager')
+        trigger_url = self.portal.portal_url() + '/mopage-stub'
+        endpoint_url = (self.portal.portal_url() + '/event-folder/mopage.events.xml' +
+                        '?partnerid=999&importid=888')
+
+        folder = create(Builder('event folder')
+                        .titled(u'Event Folder')
+                        .having(mopage_enabled=True,
+                                mopage_trigger_url=trigger_url,
+                                mopage_data_endpoint_url=endpoint_url))
+
+        events = create(Builder('event page').titled(u'The Events').within(folder))
+        self.assertEquals([], get_stub_log(self.portal))
+
+        notify(AfterUpdatedEvent(events))
+        transaction.commit()
+        runAsyncTest(lambda: None)
+        transaction.begin()
+        self.assertEquals(
+            [{'url': endpoint_url}],
+            get_stub_log(self.portal))
+
+    def test_trigger_notified_when_sl_block_is_created_in_a_events(self):
+        """When a events is published, the first page is the events, then
+        the content of the events follows in separate jobs (sl blocks,
+        recursive structures).
+        When we only trigger when the events itself is published, the content
+        will be missing.
+        Therefore we must trigger an update on any change within the events.
+        """
+        self.grant('Manager')
+        trigger_url = self.portal.portal_url() + '/mopage-stub'
+        endpoint_url = (self.portal.portal_url() + '/event-folder/mopage.events.xml' +
+                        '?partnerid=213&importid=456')
+
+        folder = create(Builder('event folder')
+                        .titled(u'Event Folder')
+                        .having(mopage_enabled=True,
+                                mopage_trigger_url=trigger_url,
+                                mopage_data_endpoint_url=endpoint_url))
+
+        events = create(Builder('event page').titled(u'The Events').within(folder))
+        block = create(Builder('sl textblock').within(events))
+
+        self.assertEquals([], get_stub_log(self.portal))
+
+        notify(AfterCreatedEvent(block))
+        transaction.commit()
+        runAsyncTest(lambda: None)
+        transaction.begin()
+        self.assertEquals(
+            [{'url': endpoint_url}],
+            get_stub_log(self.portal))
+
+    def test_publisher_event_updates_mopage_modified_date(self):
+        """The idea of the mopage modified date is that it tracks modifications
+        on the content, more specific blocks added by publisher.
+        This is important in order to tell the mopage system that things have
+        changed.
+        However, it is not the Plone modification date and it should be updated
+        by the publisher subscriber.
+        """
+        self.grant('Manager')
+        trigger_url = self.portal.portal_url() + '/mopage-stub'
+        endpoint_url = (self.portal.portal_url() + '/event-folder/mopage.events.xml' +
+                        '?partnerid=213&importid=456')
+        folder = create(Builder('event folder')
+                        .having(mopage_enabled=True,
+                                mopage_trigger_url=trigger_url,
+                                mopage_data_endpoint_url=endpoint_url))
+
+        zurich = timezone('Europe/Zurich')
+        with freeze(datetime(2016, 1, 1, tzinfo=zurich)) as clock:
+            events = create(Builder('event page').within(folder))
+            block = create(Builder('sl textblock').within(events))
+            self.assertEquals(DateTime('2016/01/01 01:00:00 GMT+1'),
+                              IMopageModificationDate(events).get_date())
+
+            clock.forward(days=1)
+            notify(AfterCreatedEvent(block))
+            self.assertEquals(DateTime('2016/01/02 00:00:00 GMT+1'),
+                              IMopageModificationDate(events).get_date())
+
+            clock.forward(days=1)
+            events.setModificationDate(DateTime())
+            notify(AfterCreatedEvent(block))
+            self.assertEquals(DateTime('2016/01/03 00:00:00 GMT+1'),
+                              IMopageModificationDate(events).get_date())

--- a/ftw/events/tests/utils.py
+++ b/ftw/events/tests/utils.py
@@ -1,0 +1,31 @@
+from ftw.simplelayout.interfaces import IPageConfiguration
+from plone import api
+from plone.uuid.interfaces import IUUID
+import transaction
+
+
+def create_page_state(obj, block):
+    page_state = {
+        "default": [
+            {
+                "cols": [
+                    {
+                        "blocks": [
+                            {
+                                "uid": IUUID(block)
+                            }
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+    page_config = IPageConfiguration(obj)
+    page_config.store(page_state)
+    transaction.commit()
+
+
+def set_allow_anonymous_view_about(state):
+    site_props = api.portal.get_tool(name='portal_properties').site_properties
+    site_props.allowAnonymousViewAbout = state
+    transaction.commit()

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,25 @@ tests_require = [
     'ftw.testing',
     'plone.app.testing',
     'plone.testing',
+    'ftw.events[mopage_publisher_receiver]',
 ]
 
 extras_require = {
     'tests': tests_require,
     'development': [
         'plonetheme.blueberry',
-    ]
+        'ftw.events[mopage_publisher_receiver]',
+    ],
+
+    # The mopage_publisher_receiver should be installed on a ftw.publisher
+    # receiver installation in order to enable the mopage trigger function.
+    # It should *NOT* be installed on ftw.pubsliher.sender site, since
+    # the trigger will then be triggered too early.
+    'mopage_publisher_receiver': [
+        'collective.taskqueue',
+        'ftw.publisher.receiver',
+        'requests',
+    ],
 }
 
 setup(
@@ -49,6 +61,7 @@ setup(
     install_requires=[
         'Plone',
         'collective.dexteritytextindexer',
+        'ftw.autofeature',
         'ftw.profilehook',
         'ftw.simplelayout [contenttypes]',
         'ftw.upgrade',


### PR DESCRIPTION
Add mopage support for events, copied from `ftw.news`.
- `mopage.events.xml` view
- Mopage trigger behavior for event folders (ftw.publisher integration)

~~I have not included locations at all, because the event page only has one simple textfield for location and you can enter whatever you want, but the mopage API requires structured data (Street, ZIP, City) and we simply do not have this information at the moment.~~
🚧 use https://github.com/4teamwork/ftw.events/pull/16 for location.