### PR TITLE
Use referencewidget to solve bug with event-listingblock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Use ftw.referencewidget for saving path relations in eventlistingblocks.
+  Beacuse of a bug in MultiContentTreeFieldWidget, references were not saved
+  after a restart of the instance which lead to the blocks not working anymore.
+  [raphael-s]
+
 - Implement mopage support. [jone]
 
 - Split up location into structured fields title, street, ZIP and city. [jone]

--- a/ftw/events/browser/eventlistingblock.py
+++ b/ftw/events/browser/eventlistingblock.py
@@ -3,6 +3,7 @@ from ftw.events import _
 from ftw.events import utils
 from ftw.events.interfaces import IEventPage
 from ftw.simplelayout.browser.blocks.base import BaseBlock
+from plone import api
 from plone.app.event.base import _prepare_range, filter_and_resort
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -98,8 +99,11 @@ class EventListingBlockView(BaseBlock):
             # `parent` is the object containing this block.
             path = '/'.join(parent.getPhysicalPath())
             query['path'] = {'query': path}
+
         elif self.context.filter_by_path:
-            paths = ['/'.join(item.getPhysicalPath()) for item in self.context.filter_by_path]
+            portal_path = '/'.join(api.portal.get().getPhysicalPath())
+            paths = ['/'.join([portal_path, path])
+                     for path in self.context.filter_by_path]
             query['path'] = {'query': paths}
 
         if self.context.subjects:

--- a/ftw/events/contents/eventlistingblock.py
+++ b/ftw/events/contents/eventlistingblock.py
@@ -1,11 +1,11 @@
 from ftw.events import _
 from ftw.events.interfaces import IEventListingBlock
+from ftw.referencewidget.widget import ReferenceWidgetFactory
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.directives import form
 from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
-from plone.formwidget.contenttree import MultiContentTreeFieldWidget
-from plone.formwidget.contenttree import ObjPathSourceBinder
+from plone.formwidget.contenttree import PathSourceBinder
 from Products.CMFPlone.interfaces.syndication import IFeedSettings
 from Products.CMFPlone.interfaces.syndication import ISyndicatable
 from z3c.relationfield import RelationChoice
@@ -35,14 +35,14 @@ class IEventListingBlockSchema(form.Schema):
         required=False,
     )
 
-    form.widget(filter_by_path=MultiContentTreeFieldWidget)
+    form.widget(filter_by_path=ReferenceWidgetFactory)
     filter_by_path = schema.List(
         title=_(u'event_listing_config_filter_path_label',
                 default=u'Limit to path'),
         description=_(u'event_listing_config_filter_path_description',
                       default=u'Only show content from a specific path.'),
         value_type=RelationChoice(
-            source=ObjPathSourceBinder(
+            source=PathSourceBinder(
                 navigation_tree_query={'is_folderish': True},
                 is_folderish=True
             ),

--- a/ftw/events/profiles/default/metadata.xml
+++ b/ftw/events/profiles/default/metadata.xml
@@ -4,5 +4,6 @@
         <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
         <dependency>profile-plone.app.event:default</dependency>
         <dependency>profile-plone.app.referenceablebehavior:default</dependency>
+        <dependency>profile-ftw.referencewidget:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/events/tests/__init__.py
+++ b/ftw/events/tests/__init__.py
@@ -1,6 +1,7 @@
 from ftw.events.testing import FUNCTIONAL_TESTING
 from ftw.events.testing import FUNCTIONAL_ZSERVER_TESTING
 from lxml import etree
+from ftw.referencewidget.tests.widgets import ReferenceBrowserWidget
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from StringIO import StringIO

--- a/ftw/events/upgrades/20161018162557_implement_ftw_referencewidget/metadata.xml
+++ b/ftw/events/upgrades/20161018162557_implement_ftw_referencewidget/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<metadata>
+    <dependencies>
+        <dependency>profile-ftw.referencewidget:default</dependency>
+    </dependencies>
+</metadata>

--- a/ftw/events/upgrades/20161018162557_implement_ftw_referencewidget/upgrade.py
+++ b/ftw/events/upgrades/20161018162557_implement_ftw_referencewidget/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ImplementFtwReferencewidget(UpgradeStep):
+    """Implement ftw referencewidget.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'collective.dexteritytextindexer',
         'ftw.autofeature',
         'ftw.profilehook',
+        'ftw.referencewidget',
         'ftw.simplelayout [contenttypes]',
         'ftw.upgrade',
         'plone.api',


### PR DESCRIPTION
Implements the newest version of `ftw.referencewidget` to fix a bug in the event-listing-block which made the blocks break on a restart. 
Now there are no longer any objects linked to possible path restrictions in the blocks.

