### PR TITLE
Fix chameleon support for mopage export.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix chameleon support for mopage export. [jone]
 
 
 1.2.0 (2016-10-18)

--- a/ftw/events/browser/templates/mopage_events.pt
+++ b/ftw/events/browser/templates/mopage_events.pt
@@ -2,13 +2,13 @@
 <import xmlns:tal="http://xml.zope.org/namespaces/tal"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="ftw.events"
-        tal:define="attrs view/import_node_attributes"
-        tal:attributes="export_time attrs/export_time;
-                        partner attrs/partner;
-                        partnerid attrs/partnerid;
-                        passwort attrs/passwort;
-                        importid attrs/importid;
-                        vaterobjekt attrs/vaterobjekt">
+        tal:define="attributes view/import_node_attributes"
+        tal:attributes="export_time attributes/export_time;
+                        partner attributes/partner;
+                        partnerid attributes/partnerid;
+                        passwort attributes/passwort;
+                        importid attributes/importid;
+                        vaterobjekt attributes/vaterobjekt">
 
     <item tal:repeat="item view/items"
           tal:attributes="mutationsdatum item/modified_date"

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,13 @@ version = '1.2.1.dev0'
 
 tests_require = [
     'ftw.builder',
+    'ftw.chameleon',
+    'ftw.events[mopage_publisher_receiver]',
     'ftw.lawgiver',
     'ftw.testbrowser',
     'ftw.testing',
     'plone.app.testing',
     'plone.testing',
-    'ftw.events[mopage_publisher_receiver]',
 ]
 
 extras_require = {


### PR DESCRIPTION
When using the variable name "attrs", chameleon does no longer evaluate the expression.