### PR TITLE
Use an integer field for the value of the zip code.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use a text field for the value of the zip code instead of an integer
+  field. [mbaechtold]
 
 
 1.2.1 (2016-10-20)

--- a/ftw/events/behaviors/location.py
+++ b/ftw/events/behaviors/location.py
@@ -2,9 +2,7 @@ from ftw.events import _
 from plone.directives.form import IFormFieldProvider
 from plone.directives.form import Schema
 from zope.interface import alsoProvides
-from zope.schema import Int
 from zope.schema import TextLine
-
 
 
 class ILocationFields(Schema):
@@ -27,7 +25,7 @@ class ILocationFields(Schema):
         default=None,
     )
 
-    location_zip = Int(
+    location_zip = TextLine(
         title=_(
             u'label_location_zip',
             default=u'Location: ZIP code'

--- a/ftw/events/contents/eventpage.py
+++ b/ftw/events/contents/eventpage.py
@@ -34,7 +34,7 @@ class EventPage(Container):
             return ', '.join(filter(None, (
                 storage.location_title,
                 storage.location_street,
-                ' '.join((str(storage.location_zip or ''),
+                ' '.join((storage.location_zip or '',
                           storage.location_city or '')).strip(),
             ))) or ''
 

--- a/ftw/events/tests/test_event_listing.py
+++ b/ftw/events/tests/test_event_listing.py
@@ -83,7 +83,7 @@ class TestEventListing(FunctionalTestCase):
                        .titled(u'My Event')
                        .having(location_title='Infinite Loop 1',
                                location_street='Hamburgstrasse 3743x',
-                               location_zip=12345,
+                               location_zip='12345',
                                location_city='Hamburg')
                        .within(event_folder))
         browser.login()

--- a/ftw/events/tests/test_mopage_export.py
+++ b/ftw/events/tests/test_mopage_export.py
@@ -42,7 +42,7 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
                         subjects=('Kaffee', 'Wanderausstellung'),
                         location_title='Kunstmuseum Bern',
                         location_street='Hodlerstrasse 8',
-                        location_zip=3011,
+                        location_zip='3011',
                         location_city='Bern'))
 
             lorem = RichTextValue(self.asset('lorem1.html'))


### PR DESCRIPTION
This way the field won't get formatted incorrectly in the edit form.

## Before

<img width="1440" alt="screenshot vorher" src="https://cloud.githubusercontent.com/assets/28220/20923106/2f0c5282-bbab-11e6-878e-d0957fb4abd6.png">

## After

<img width="1440" alt="screenshot nachher" src="https://cloud.githubusercontent.com/assets/28220/20923103/2d4e376c-bbab-11e6-8142-807875351f24.png">
