### PR TITLE
Display action text next to icon

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Show text of "ICS Export" action again.
+  [Kevin Bieri]
 
 
 1.3.0 (2016-12-06)

--- a/ftw/events/resources/events-theming.scss
+++ b/ftw/events/resources/events-theming.scss
@@ -57,11 +57,3 @@
     @extend .fa-icon;
     @extend .fa-calendar;
 }
-#document-action-ics_export a {
-    font-size: 0px;
-}
-
-#document-action-ics_export > a:before {
-    padding-left: 0.5em;
-    font-size: 1.2rem;
-}


### PR DESCRIPTION
The text should not be set to hidden by the ftw.events package.
This behavior should be done in a theme or policy package.

![screen shot 2016-12-08 at 17 57 27](https://cloud.githubusercontent.com/assets/1637820/21019307/39a7f1bc-bd70-11e6-9b1a-ec76d04ed5bd.png)
