### PR TITLE
Add missing upgrade step from 1.2.0

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Convert "filter_by_path" references of the event listing blocks.
+  This should have been done in 1.2.0.
+  [mbaechtold]
+
 - Show text of "ICS Export" action again.
   [Kevin Bieri]
 

--- a/ftw/events/upgrades/20170119084718_convert_filter_by_path_references/upgrade.py
+++ b/ftw/events/upgrades/20170119084718_convert_filter_by_path_references/upgrade.py
@@ -1,0 +1,24 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ConvertFilterByPathReferences(UpgradeStep):
+    """Convert "filter_by_path" references.
+    """
+
+    def __call__(self):
+        objs = self.objects(
+            {'portal_type': 'ftw.events.EventListingBlock'},
+            message='Convert filter_by_path references'
+        )
+        for obj in objs:
+            if obj.filter_by_path:
+                paths = []
+                for path in obj.filter_by_path:
+                    if not hasattr(path, 'getPhysicalPath'):
+                        # Has already been converted.
+                        paths.append(path)
+                    else:
+                        paths.append(
+                            u'/'.join(path.getPhysicalPath())
+                        )
+                obj.filter_by_path = paths


### PR DESCRIPTION
The upgrade step converts "filter_by_path" references of the event listing blocks.

In version 1.2.0 (see https://github.com/4teamwork/ftw.events/pull/17) the references of the "filter_by_path" field of the event listing block has been changed from "ObjPathSourceBinder" to "PathSourceBinder". Event listing blocks created before 1.2.0 still hold objects which need to be converted to paths.