### PR TITLE
Make Events linkable in TinyMCE editor.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make Event and EventFolder linkable in TinyMCE
+  [raphael-s]
 
 
 1.4.0 (2017-01-19)

--- a/ftw/events/profiles/default/tinymce.xml
+++ b/ftw/events/profiles/default/tinymce.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+        <linkable purge="False">
+            <element value="ftw.events.EventFolder"/>
+            <element value="ftw.events.EventPage"/>
+        </linkable>
+    </resourcetypes>
+</object>


### PR DESCRIPTION
Makes `EventPage` and `EventFodler` linkable in TinyMCE.

Do no include upgrade step, since this could change existing projects.

closes #22 