### PR TITLE
Add option to hide an empty listing block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Add option allowing to hide the event listing block if there are no
+  events to be shown. [mbaechtold]
+
 - Show inactive events if the user has the permission to add
   events. [mbaechtold]
 

--- a/ftw/events/browser/eventlistingblock.py
+++ b/ftw/events/browser/eventlistingblock.py
@@ -3,6 +3,7 @@ from ftw.events import _
 from ftw.events import utils
 from ftw.events.interfaces import IEventPage
 from ftw.simplelayout.browser.blocks.base import BaseBlock
+from ftw.simplelayout.contenttypes.behaviors import IHiddenBlock
 from plone import api
 from plone.app.event.base import _prepare_range, filter_and_resort
 from Products.CMFCore.utils import getToolByName
@@ -36,6 +37,7 @@ class EventListingBlockView(BaseBlock):
             'show_title': self.context.show_title,
             'more_items_link_url': more_items_link_url,
             'more_items_link_label': more_items_link_label,
+            'hide_empty_block':  self.context.hide_empty_block,
         }
 
         return info

--- a/ftw/events/browser/templates/eventlistingblock.pt
+++ b/ftw/events/browser/templates/eventlistingblock.pt
@@ -10,8 +10,11 @@
 
     <tal:events tal:define="items view/get_items;">
 
-        <p tal:condition="not: items"
-           i18n:translate="eventlisting_no_content_text">No content available.</p>
+        <tal:no-items tal:condition="not: items">
+           <p i18n:translate="eventlisting_no_content_text">No content available.</p>
+           <p i18n:translate="eventlisting_hide_empty_block_text"
+              tal:condition="block_info/hide_empty_block">The block is only visible to editors so it can still be edited.</p>
+        </tal:no-items>
 
         <ul class="event-row">
             <li tal:repeat="item items">

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-16 14:53+0000\n"
+"POT-Creation-Date: 2017-03-15 14:49+0000\n"
 "PO-Revision-Date: 2016-10-18 11:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -70,6 +70,11 @@ msgstr "Wann"
 msgid "Where"
 msgstr "Wo"
 
+#. Default: "Hide the block if there are not events to be shown."
+#: ./ftw/events/contents/eventlistingblock.py:134
+msgid "description_hide_empty_block"
+msgstr "Der Block wird nicht angezeigt, wenn keine Veranstaltungen vorhanden sind."
+
 #. Default: "The mopage data endpoint URL points to the \"mopage.events.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/events/mopage.events.xml?partnerid=3&importid=6"
 #: ./ftw/events/behaviors/mopage.py:64
 msgid "description_mopage_data_endpoint_url"
@@ -81,98 +86,103 @@ msgid "description_mopage_trigger_url"
 msgstr "Die Trigger-URL zeigt auf die Mopage-API. Sie enthält kein \"?url\"-Parameter, dieser wird automatisch angefügt. Beispiel: https://un:pw@xml.mopage.ch/infoservice/xml.php"
 
 #. Default: "This custom label will not be translated."
-#: ./ftw/events/contents/eventlistingblock.py:114
+#: ./ftw/events/contents/eventlistingblock.py:118
 msgid "description_more_items_link_label"
 msgstr "Wird nicht übersetzt."
 
 #. Default: "This title will not be translated."
-#: ./ftw/events/contents/eventlistingblock.py:122
+#: ./ftw/events/contents/eventlistingblock.py:126
 msgid "description_more_items_view_title"
 msgstr "Wird nicht übersetzt."
 
 #. Default: "Show title"
-#: ./ftw/events/contents/eventlistingblock.py:27
+#: ./ftw/events/contents/eventlistingblock.py:31
 msgid "event_listing_block_show_title_label"
 msgstr "Titel anzeigen"
 
 #. Default: "You cannot filter by path and current context at the same time."
-#: ./ftw/events/contents/eventlistingblock.py:132
+#: ./ftw/events/contents/eventlistingblock.py:145
 msgid "event_listing_config_current_context_and_path_error"
 msgstr "Es ist nicht möglich, gleichzeitig nach Pfad und aktuellem Bereich zu filtern."
 
 #. Default: "The maximum length of the item's description. Longer descriptions will be cropped. Enter 0 for no limitation."
-#: ./ftw/events/contents/eventlistingblock.py:95
+#: ./ftw/events/contents/eventlistingblock.py:99
 msgid "event_listing_config_description_length_description"
 msgstr "Maximale Länge der Beschreibung. Längere Beschreibungen werden gekürzt (0 = keine Einschränkung)."
 
 #. Default: "Length of the description"
-#: ./ftw/events/contents/eventlistingblock.py:93
+#: ./ftw/events/contents/eventlistingblock.py:97
 msgid "event_listing_config_description_length_label"
 msgstr "Länge der Beschreibung"
 
 #. Default: "Only show items from the current context."
-#: ./ftw/events/contents/eventlistingblock.py:58
+#: ./ftw/events/contents/eventlistingblock.py:62
 msgid "event_listing_config_filter_current_context_description"
 msgstr "Nur Einträge aus dem aktuellen Bereich anzeigen."
 
 #. Default: "Limit to current context"
-#: ./ftw/events/contents/eventlistingblock.py:56
+#: ./ftw/events/contents/eventlistingblock.py:60
 msgid "event_listing_config_filter_current_context_label"
 msgstr "Auf aktuellen Bereich einschränken"
 
 #. Default: "Only show content from a specific path."
-#: ./ftw/events/contents/eventlistingblock.py:42
+#: ./ftw/events/contents/eventlistingblock.py:46
 msgid "event_listing_config_filter_path_description"
 msgstr "Nur Einträge aus einem bestimmten Pfad anzeigen"
 
 #. Default: "Limit to path"
-#: ./ftw/events/contents/eventlistingblock.py:40
+#: ./ftw/events/contents/eventlistingblock.py:44
 msgid "event_listing_config_filter_path_label"
 msgstr "Auf Pfad einschränken"
 
 #. Default: "The number of items to be shown at most. Enter 0 for no limitation."
-#: ./ftw/events/contents/eventlistingblock.py:66
+#: ./ftw/events/contents/eventlistingblock.py:70
 msgid "event_listing_config_quantity_description"
 msgstr "Die maximale Anzahl anzuzeigender Einträge (0 = keine Einschränkung)."
 
 #. Default: "Quantity"
-#: ./ftw/events/contents/eventlistingblock.py:65
+#: ./ftw/events/contents/eventlistingblock.py:69
 msgid "event_listing_config_quantity_label"
 msgstr "Anzahl"
 
 #. Default: "Show the description of the item"
-#: ./ftw/events/contents/eventlistingblock.py:87
+#: ./ftw/events/contents/eventlistingblock.py:91
 msgid "event_listing_config_show_description_label"
 msgstr "Beschreibung anzeigen"
 
 #. Default: "Show link to more items"
-#: ./ftw/events/contents/eventlistingblock.py:103
+#: ./ftw/events/contents/eventlistingblock.py:107
 msgid "event_listing_config_show_more_items_link"
 msgstr "Einen Link zu weiteren Einträgen anzeigen."
 
 #. Default: "Only items with the selected subjects will be shown."
-#: ./ftw/events/contents/eventlistingblock.py:77
+#: ./ftw/events/contents/eventlistingblock.py:81
 msgid "event_listing_config_subjects_description"
 msgstr "Es werden nur Einträge angezeigt, welche mit diesen Stichworten versehen sind."
 
 #. Default: "Filter by subject"
-#: ./ftw/events/contents/eventlistingblock.py:75
+#: ./ftw/events/contents/eventlistingblock.py:79
 msgid "event_listing_config_subjects_label"
 msgstr "Nach Stichworten filtern"
 
 #. Default: "Title"
-#: ./ftw/events/contents/eventlistingblock.py:20
+#: ./ftw/events/contents/eventlistingblock.py:24
 msgid "event_listing_config_title_label"
 msgstr "Titel"
 
 #. Default: "Render a link to a page which renders more items (only if there is at least one item)."
-#: ./ftw/events/contents/eventlistingblock.py:105
+#: ./ftw/events/contents/eventlistingblock.py:109
 msgid "event_listing_show_more_items_link_description"
 msgstr "Einen Link zu weiteren Einträgen anzeigen (wird nur angezeigt, wenn es mindestens einen Eintrag gibt)."
 
+#. Default: "The block is only visible to editors so it can still be edited."
+#: ./ftw/events/browser/templates/eventlistingblock.pt:15
+msgid "eventlisting_hide_empty_block_text"
+msgstr "Dieser Block ist nur noch für Benutzer sichtbar, die Inhalte bearbeiten dürfen. So kann der Block weiterhin bearbeitet werden."
+
 #. Default: "No content available."
 #: ./ftw/events/browser/templates/eventlisting.pt:20
-#: ./ftw/events/browser/templates/eventlistingblock.pt:13
+#: ./ftw/events/browser/templates/eventlistingblock.pt:14
 msgid "eventlisting_no_content_text"
 msgstr "Kein Inhalt verfügbar."
 
@@ -181,9 +191,14 @@ msgid "ftw.events"
 msgstr "ftw.events"
 
 #. Default: "Exclude past events"
-#: ./ftw/events/contents/eventlistingblock.py:33
+#: ./ftw/events/contents/eventlistingblock.py:37
 msgid "label_exclude_past_events"
 msgstr "Vergangene Veranstaltungen nicht anzeigen"
+
+#. Default: "Hide empty block"
+#: ./ftw/events/contents/eventlistingblock.py:132
+msgid "label_hide_empty_block"
+msgstr "Leeren Block ausblenden"
 
 #. Default: "ICS Export"
 #: ./ftw/events/viewlets/templates/event_details.pt:7
@@ -221,12 +236,12 @@ msgid "label_mopage_trigger_url"
 msgstr "Mopage Trigger URL"
 
 #. Default: "Label for the \"more items\" link"
-#: ./ftw/events/contents/eventlistingblock.py:112
+#: ./ftw/events/contents/eventlistingblock.py:116
 msgid "label_more_items_link_label"
 msgstr "Label für den Link \"Weitere Einträge\""
 
 #. Default: "Title of the view behind the \"more items\" link"
-#: ./ftw/events/contents/eventlistingblock.py:120
+#: ./ftw/events/contents/eventlistingblock.py:124
 msgid "label_more_items_view_title"
 msgstr "Titel der View hinter dem Link \"Weitere Einträge\""
 
@@ -236,8 +251,8 @@ msgid "label_trigger_enabled"
 msgstr "Mopage Trigger aktiviert"
 
 #. Default: "More Items"
-#: ./ftw/events/browser/eventlistingblock.py:30
-#: ./ftw/events/browser/templates/eventlistingblock.pt:36
+#: ./ftw/events/browser/eventlistingblock.py:31
+#: ./ftw/events/browser/templates/eventlistingblock.pt:39
 msgid "more_items_link_label"
 msgstr "Weitere Einträge"
 

--- a/ftw/events/locales/ftw.events.pot
+++ b/ftw/events/locales/ftw.events.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-16 14:53+0000\n"
+"POT-Creation-Date: 2017-03-15 14:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -70,6 +70,11 @@ msgstr ""
 msgid "Where"
 msgstr ""
 
+#. Default: "Hide the block if there are not events to be shown."
+#: ./ftw/events/contents/eventlistingblock.py:134
+msgid "description_hide_empty_block"
+msgstr ""
+
 #. Default: "The mopage data endpoint URL points to the \"mopage.events.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/events/mopage.events.xml?partnerid=3&importid=6"
 #: ./ftw/events/behaviors/mopage.py:64
 msgid "description_mopage_data_endpoint_url"
@@ -81,98 +86,103 @@ msgid "description_mopage_trigger_url"
 msgstr ""
 
 #. Default: "This custom label will not be translated."
-#: ./ftw/events/contents/eventlistingblock.py:114
+#: ./ftw/events/contents/eventlistingblock.py:118
 msgid "description_more_items_link_label"
 msgstr ""
 
 #. Default: "This title will not be translated."
-#: ./ftw/events/contents/eventlistingblock.py:122
+#: ./ftw/events/contents/eventlistingblock.py:126
 msgid "description_more_items_view_title"
 msgstr ""
 
 #. Default: "Show title"
-#: ./ftw/events/contents/eventlistingblock.py:27
+#: ./ftw/events/contents/eventlistingblock.py:31
 msgid "event_listing_block_show_title_label"
 msgstr ""
 
 #. Default: "You cannot filter by path and current context at the same time."
-#: ./ftw/events/contents/eventlistingblock.py:132
+#: ./ftw/events/contents/eventlistingblock.py:145
 msgid "event_listing_config_current_context_and_path_error"
 msgstr ""
 
 #. Default: "The maximum length of the item's description. Longer descriptions will be cropped. Enter 0 for no limitation."
-#: ./ftw/events/contents/eventlistingblock.py:95
+#: ./ftw/events/contents/eventlistingblock.py:99
 msgid "event_listing_config_description_length_description"
 msgstr ""
 
 #. Default: "Length of the description"
-#: ./ftw/events/contents/eventlistingblock.py:93
+#: ./ftw/events/contents/eventlistingblock.py:97
 msgid "event_listing_config_description_length_label"
 msgstr ""
 
 #. Default: "Only show items from the current context."
-#: ./ftw/events/contents/eventlistingblock.py:58
+#: ./ftw/events/contents/eventlistingblock.py:62
 msgid "event_listing_config_filter_current_context_description"
 msgstr ""
 
 #. Default: "Limit to current context"
-#: ./ftw/events/contents/eventlistingblock.py:56
+#: ./ftw/events/contents/eventlistingblock.py:60
 msgid "event_listing_config_filter_current_context_label"
 msgstr ""
 
 #. Default: "Only show content from a specific path."
-#: ./ftw/events/contents/eventlistingblock.py:42
+#: ./ftw/events/contents/eventlistingblock.py:46
 msgid "event_listing_config_filter_path_description"
 msgstr ""
 
 #. Default: "Limit to path"
-#: ./ftw/events/contents/eventlistingblock.py:40
+#: ./ftw/events/contents/eventlistingblock.py:44
 msgid "event_listing_config_filter_path_label"
 msgstr ""
 
 #. Default: "The number of items to be shown at most. Enter 0 for no limitation."
-#: ./ftw/events/contents/eventlistingblock.py:66
+#: ./ftw/events/contents/eventlistingblock.py:70
 msgid "event_listing_config_quantity_description"
 msgstr ""
 
 #. Default: "Quantity"
-#: ./ftw/events/contents/eventlistingblock.py:65
+#: ./ftw/events/contents/eventlistingblock.py:69
 msgid "event_listing_config_quantity_label"
 msgstr ""
 
 #. Default: "Show the description of the item"
-#: ./ftw/events/contents/eventlistingblock.py:87
+#: ./ftw/events/contents/eventlistingblock.py:91
 msgid "event_listing_config_show_description_label"
 msgstr ""
 
 #. Default: "Show link to more items"
-#: ./ftw/events/contents/eventlistingblock.py:103
+#: ./ftw/events/contents/eventlistingblock.py:107
 msgid "event_listing_config_show_more_items_link"
 msgstr ""
 
 #. Default: "Only items with the selected subjects will be shown."
-#: ./ftw/events/contents/eventlistingblock.py:77
+#: ./ftw/events/contents/eventlistingblock.py:81
 msgid "event_listing_config_subjects_description"
 msgstr ""
 
 #. Default: "Filter by subject"
-#: ./ftw/events/contents/eventlistingblock.py:75
+#: ./ftw/events/contents/eventlistingblock.py:79
 msgid "event_listing_config_subjects_label"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/events/contents/eventlistingblock.py:20
+#: ./ftw/events/contents/eventlistingblock.py:24
 msgid "event_listing_config_title_label"
 msgstr ""
 
 #. Default: "Render a link to a page which renders more items (only if there is at least one item)."
-#: ./ftw/events/contents/eventlistingblock.py:105
+#: ./ftw/events/contents/eventlistingblock.py:109
 msgid "event_listing_show_more_items_link_description"
+msgstr ""
+
+#. Default: "The block is only visible to editors so it can still be edited."
+#: ./ftw/events/browser/templates/eventlistingblock.pt:15
+msgid "eventlisting_hide_empty_block_text"
 msgstr ""
 
 #. Default: "No content available."
 #: ./ftw/events/browser/templates/eventlisting.pt:20
-#: ./ftw/events/browser/templates/eventlistingblock.pt:13
+#: ./ftw/events/browser/templates/eventlistingblock.pt:14
 msgid "eventlisting_no_content_text"
 msgstr ""
 
@@ -181,8 +191,13 @@ msgid "ftw.events"
 msgstr ""
 
 #. Default: "Exclude past events"
-#: ./ftw/events/contents/eventlistingblock.py:33
+#: ./ftw/events/contents/eventlistingblock.py:37
 msgid "label_exclude_past_events"
+msgstr ""
+
+#. Default: "Hide empty block"
+#: ./ftw/events/contents/eventlistingblock.py:132
+msgid "label_hide_empty_block"
 msgstr ""
 
 #. Default: "ICS Export"
@@ -221,12 +236,12 @@ msgid "label_mopage_trigger_url"
 msgstr ""
 
 #. Default: "Label for the \"more items\" link"
-#: ./ftw/events/contents/eventlistingblock.py:112
+#: ./ftw/events/contents/eventlistingblock.py:116
 msgid "label_more_items_link_label"
 msgstr ""
 
 #. Default: "Title of the view behind the \"more items\" link"
-#: ./ftw/events/contents/eventlistingblock.py:120
+#: ./ftw/events/contents/eventlistingblock.py:124
 msgid "label_more_items_view_title"
 msgstr ""
 
@@ -236,8 +251,8 @@ msgid "label_trigger_enabled"
 msgstr ""
 
 #. Default: "More Items"
-#: ./ftw/events/browser/eventlistingblock.py:30
-#: ./ftw/events/browser/templates/eventlistingblock.pt:36
+#: ./ftw/events/browser/eventlistingblock.py:31
+#: ./ftw/events/browser/templates/eventlistingblock.pt:39
 msgid "more_items_link_label"
 msgstr ""
 

--- a/ftw/events/resources/events-theming.scss
+++ b/ftw/events/resources/events-theming.scss
@@ -60,3 +60,14 @@
     display: block;
     float: right;
 }
+
+// Hide empty event listing block for anonymous users.
+.portlet.SimplelayoutPortlet .ftw-events-eventlistingblock.hidden {
+  display: none;
+}
+
+// Add special border to empty listing block for authenticated users.
+body.userrole-authenticated .portlet.SimplelayoutPortlet .ftw-events-eventlistingblock.hidden {
+  @include boxshadow(0 0 20px 0 $color-warning);
+  display: block;
+}

--- a/ftw/events/tests/test_event_listingblock.py
+++ b/ftw/events/tests/test_event_listingblock.py
@@ -562,3 +562,31 @@ class TestEventListingBlock(FunctionalTestCase):
             [],
             self._get_event_titles_from_block(browser),
         )
+
+    @browsing
+    def test_block_without_events_can_be_marked_as_hidden(self, browser):
+        """
+        This test makes sure that there is a CSS class "hidden" on the block
+        if the block is empty and the block has been configured accordingly.
+        """
+        page = create(Builder('sl content page'))
+        block = create(Builder('event listing block')
+                       .within(page)
+                       .titled(u'Event listing block'))
+
+        def _block_has_hidden_class(browser):
+            return 'hidden' in browser.css('.ftw-events-eventlistingblock').first.attrib['class']
+
+        browser.login()
+
+        # Make sure the block has no "hidden" class.
+        browser.visit(page)
+        self.assertFalse(_block_has_hidden_class(browser))
+
+        # Edit the block.
+        browser.visit(block, view='edit')
+        browser.fill({u'Hide empty block': True}).find('Save').click()
+
+        # Make sure the block has a "hidden" class now.
+        browser.visit(page)
+        self.assertTrue(_block_has_hidden_class(browser))

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'ftw.autofeature',
         'ftw.profilehook',
         'ftw.referencewidget',
-        'ftw.simplelayout [contenttypes]',
+        'ftw.simplelayout [contenttypes] >= 1.14.0',
         'ftw.upgrade',
         'plone.api',
         'plone.app.dexterity',


### PR DESCRIPTION
This option makes use of a feature in "ftw.simplelayout" where a block can be hidden visually.