### PR TITLE
Show inactive events if the user has the permission to add events.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Show inactive events if the user has the permission to add
+  events. [mbaechtold]
+
 - Move the global ics export documentaction.
   [Kevin Bieri]
 

--- a/ftw/events/browser/eventlistingblock.py
+++ b/ftw/events/browser/eventlistingblock.py
@@ -109,6 +109,15 @@ class EventListingBlockView(BaseBlock):
         if self.context.subjects:
             query['Subject'] = self.context.subjects
 
+        # Show inactive events if the current user is allowed to add events on the
+        # parent of the event listing block. We must only render the inactive events
+        # if the block renders events from its parent (in order not to allow the user
+        # to view news items he is not allowed to see).
+        if self.context.current_context \
+                and not self.context.filter_by_path \
+                and api.user.has_permission('ftw.events: Add Event Page', obj=parent):
+            query['show_inactive'] = True
+
         return query
 
     def get_event_page_dict(self, brain):

--- a/ftw/events/tests/utils.py
+++ b/ftw/events/tests/utils.py
@@ -1,6 +1,8 @@
 from ftw.simplelayout.interfaces import IPageConfiguration
 from plone import api
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
+from zope.component.hooks import getSite
 import transaction
 
 
@@ -28,4 +30,12 @@ def create_page_state(obj, block):
 def set_allow_anonymous_view_about(state):
     site_props = api.portal.get_tool(name='portal_properties').site_properties
     site_props.allowAnonymousViewAbout = state
+    transaction.commit()
+
+
+def enable_behavior(behavior, portal_type):
+    portal_types = getToolByName(getSite(), 'portal_types')
+    behaviors = list(portal_types[portal_type].behaviors)
+    behaviors.append(behavior)
+    portal_types[portal_type].behaviors = tuple(behaviors)
     transaction.commit()


### PR DESCRIPTION
Inactive event pages will now be shown in the event listing view (and thus the event listing block) if the user has the permission to add event pages..

Important: the event pages will only be shown if event pages from a single container are shown. Otherwise a user could trick the system and be able to see inactive event pages from a path where he does not have the permission to add events.