### PR TITLE
Fix rendering of inactive event pages.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug which prevented inactive event pages from being shown in
+  combination with Solr. [mbaechtold]
 
 
 1.6.0 (2017-03-22)

--- a/ftw/events/browser/eventlistingblock.py
+++ b/ftw/events/browser/eventlistingblock.py
@@ -64,7 +64,7 @@ class EventListingBlockView(BaseBlock):
         start, end = _prepare_range(self.context, start, end)
 
         brains = catalog.searchResults(
-            self.get_query(start, end)
+            **self.get_query(start, end)
         )
 
         # Inspired by `plone.app.event.base.get_events`.


### PR DESCRIPTION
This has only been noticed once it has been installed on the production server where Solr is installed (Solr is not installed in the tests).