### PR TITLE
Respect `exclude_past_events` setting of block, also on the event listing view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Respect `exclude_past_events` setting of block, also on the event listing view.
+  [mathias.leimgruber]
 
 
 1.6.1 (2017-03-30)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
+- Add compatibilty with lates ftw.testbrowser 1.21.0.
+  [mathias.leimgruber]
+
 - Respect `exclude_past_events` setting of block, also on the event listing view.
   [mathias.leimgruber]
 

--- a/ftw/events/browser/eventlisting.py
+++ b/ftw/events/browser/eventlisting.py
@@ -32,7 +32,8 @@ class EventListing(BrowserView):
             context=self.context,
             request=self.request,
         )
-        block_query = block_view.get_query()
+        start, end = block_view.get_dates_for_query()
+        block_query = block_view.get_query(start, end)
         return block_query
 
     def get_items(self):

--- a/ftw/events/browser/eventlistingblock.py
+++ b/ftw/events/browser/eventlistingblock.py
@@ -49,20 +49,7 @@ class EventListingBlockView(BaseBlock):
         """
         catalog = getToolByName(self.context, 'portal_catalog')
 
-        start = None
-        end = None
-
-        if self.context.exclude_past_events:
-            # Start from midnight of today. This way the query will also include
-            # events which have ended just a few hours ago.
-            midnight_of_today = datetime.datetime.now().replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-            start = midnight_of_today
-
-        # Inspired by `plone.app.event.base.get_events`.
-        start, end = _prepare_range(self.context, start, end)
-
+        start, end = self.get_dates_for_query()
         brains = catalog.searchResults(
             **self.get_query(start, end)
         )
@@ -79,6 +66,20 @@ class EventListingBlockView(BaseBlock):
         items = [self.get_event_page_dict(brain) for brain in brains]
 
         return items
+
+    def get_dates_for_query(self):
+        start = None
+        if self.context.exclude_past_events:
+            # Start from midnight of today. This way the query will also
+            # include events which have ended just a few hours ago.
+            midnight_of_today = datetime.datetime.now().replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            start = midnight_of_today
+
+        # Inspired by `plone.app.event.base.get_events`.
+        start, end = _prepare_range(self.context, start, None)
+        return start, end
 
     def get_query(self, start=None, end=None):
         query = {

--- a/ftw/events/tests/test_event_listing.py
+++ b/ftw/events/tests/test_event_listing.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from ftw.events.tests import FunctionalTestCase
 from ftw.events.tests.utils import enable_behavior
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
 from plone import api
 
 
@@ -27,7 +28,8 @@ class TestEventListing(FunctionalTestCase):
 
         browser.login()
 
-        # Get the event folder's event listing block which has been created automatically.
+        # Get the event folder's event listing block which has been created
+        # automatically.
         block = api.content.find(
             portal_type='ftw.events.EventListingBlock',
             within=event_folder
@@ -91,7 +93,8 @@ class TestEventListing(FunctionalTestCase):
                        .within(event_folder))
         browser.login()
 
-        # Get the event folder's event listing block which has been created automatically.
+        # Get the event folder's event listing block which has been created
+        # automatically.
         block = api.content.find(
             portal_type='ftw.events.EventListingBlock',
             within=event_folder
@@ -126,7 +129,8 @@ class TestEventListing(FunctionalTestCase):
                .within(event_folder)
                .having(effective=datetime.now() + timedelta(days=10)))
 
-        # Get the event folder's event listing block which has been created automatically.
+        # Get the event folder's event listing block which has been created
+        # automatically.
         block = api.content.find(
             portal_type='ftw.events.EventListingBlock',
             within=event_folder
@@ -146,3 +150,46 @@ class TestEventListing(FunctionalTestCase):
             [],
             browser.css('.event-row .title').text
         )
+
+    @browsing
+    def test_listing_does_not_render_past_events(self, browser):
+        page = create(Builder('sl content page'))
+        event_folder = create(Builder('event folder')
+                              .titled(u'Event Folder')
+                              .within(page))
+        create(Builder('event listing block')
+               .within(page)
+               .titled(u'Event listing block')
+               .having(show_more_items_link=True,
+                       exclude_past_events=True))
+
+        with freeze(datetime(2010, 7, 1, 15, 0, 0)):
+            create(Builder('event page')
+                   .titled(u'Past event')
+                   .starting(datetime(2010, 1, 1))
+                   .ending(datetime(2010, 1, 1))
+                   .within(event_folder))
+            create(Builder('event page')
+                   .titled(u'Today event')
+                   .starting(datetime(2010, 7, 1, 12, 0, 0))
+                   .ending(datetime(2010, 7, 1, 18, 0, 0))
+                   .within(event_folder))
+            create(Builder('event page')
+                   .titled(u'Future event')
+                   .starting(datetime(2010, 7, 2))
+                   .ending(datetime(2010, 7, 2))
+                   .within(event_folder))
+            create(Builder('event page')
+                   .titled(u'Event which ended a few hours ago')
+                   .starting(datetime(2010, 7, 1, 9, 0, 0))
+                   .ending(datetime(2010, 7, 1, 14, 0, 0))
+                   .within(event_folder))
+
+            browser.login().visit(page)
+            browser.css('a.event-listingblock-moreitemslink').first.click()
+            self.assertEqual(
+                ['Event which ended a few hours ago',
+                 'Today event',
+                 'Future event'],
+                browser.css('.event-item h3.title').text
+            )

--- a/ftw/events/tests/test_event_listing.py
+++ b/ftw/events/tests/test_event_listing.py
@@ -68,7 +68,7 @@ class TestEventListing(FunctionalTestCase):
         # Configure a custom title.
         browser.login().visit(block, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({
             'Title of the view behind the "more items" link': u'All my events',
         })

--- a/ftw/events/tests/test_event_listingblock.py
+++ b/ftw/events/tests/test_event_listingblock.py
@@ -73,7 +73,7 @@ class TestEventListingBlock(FunctionalTestCase):
         # Tell the block to no longer display the title.
         browser.login().visit(block, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({
             'Show title': False,
         })
@@ -150,7 +150,7 @@ class TestEventListingBlock(FunctionalTestCase):
         # Edit the block and set a path (not possible with builder).
         browser.visit(block, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({
             'Limit to path': event_folder2,
         })
@@ -184,7 +184,7 @@ class TestEventListingBlock(FunctionalTestCase):
         # Edit the existing block.
         browser.visit(block, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({
             'Title': u'Not relevant for this test',
             'Limit to path': '/'.join(event_folder.getPhysicalPath()),
@@ -192,7 +192,7 @@ class TestEventListingBlock(FunctionalTestCase):
         })
         browser.find_button_by_label('Save').click()
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
 
         # Make sure that the form refuses to save.
         self.assertEqual(
@@ -237,7 +237,7 @@ class TestEventListingBlock(FunctionalTestCase):
         # Tell the block to no longer filter by the current context.
         browser.login().visit(block, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({
             'Limit to current context': False,
         })
@@ -415,7 +415,7 @@ class TestEventListingBlock(FunctionalTestCase):
         # Tell the block to no longer render the link
         browser.login().visit(block, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({
             'Show link to more items': False,
         })

--- a/ftw/events/tests/test_ics_view.py
+++ b/ftw/events/tests/test_ics_view.py
@@ -3,9 +3,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.events.tests import RealFuncitionalTestCase
 from ftw.testbrowser import browsing
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import TEST_USER_PASSWORD
-import requests
 from ftw.testbrowser.core import LIB_REQUESTS
 
 
@@ -28,8 +25,7 @@ class TestIsICSView(RealFuncitionalTestCase):
         browser.request_library = LIB_REQUESTS
         browser.login().visit(self.event, view="ics_view")
 
-        response = browser.response
-        body = response.content
+        body = browser.contents
         self.assertIn('SUMMARY:A Event', body)
         self.assertIn('BEGIN:VCALENDAR', body)
         self.assertIn('BEGIN:VEVENT', body)


### PR DESCRIPTION
Before the result on the listing view after clicking on the "Show further event" was completely different. 