### PR TITLE
Implement RSS feed for events

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add RSS view for eventlisting block.
+  [raphael-s]
 
 
 1.7.0 (2017-12-08)

--- a/ftw/events/browser/configure.zcml
+++ b/ftw/events/browser/configure.zcml
@@ -19,6 +19,14 @@
         />
 
     <browser:page
+        for="ftw.events.interfaces.IEventListingBlock"
+        name="events_rss"
+        class=".eventlisting.EventListingRss"
+        template="./templates/events_rss.pt"
+        permission="zope2.View"
+        />
+
+    <browser:page
         for="*"
         name="mopage.events.xml"
         class=".mopage.MopageEvents"

--- a/ftw/events/browser/eventlisting.py
+++ b/ftw/events/browser/eventlisting.py
@@ -77,3 +77,20 @@ class EventListing(BrowserView):
             context=self.request
         )
         return self.context.more_items_view_title or fallback_title
+
+
+class EventListingRss(EventListing):
+
+    @property
+    def description(self):
+        return _(u'label_feed_desc',
+                 default=u'${title} - Events Feed',
+                 mapping={'title': self.context.Title().decode('utf-8')})
+
+    @property
+    def link(self):
+        url = self.context.absolute_url() + '/' + self.__name__
+        return '<link>{}</link>'.format(url)
+
+    def get_item_link(self, url):
+        return '<link>{}</link>'.format(url)

--- a/ftw/events/browser/eventlistingblock.py
+++ b/ftw/events/browser/eventlistingblock.py
@@ -23,6 +23,11 @@ class EventListingBlockView(BaseBlock):
         This method returns a dict containing information to be used in
         the block's template.
         """
+        rss_link_url = ''
+        if self.context.show_rss_link:
+            rss_link_url = '/'.join([self.context.absolute_url(),
+                                     'events_rss'])
+
         more_items_link_url = ''
         if self.context.show_more_items_link:
             more_items_link_url = '/'.join([self.context.absolute_url(), 'events'])
@@ -36,6 +41,7 @@ class EventListingBlockView(BaseBlock):
         info = {
             'title': self.context.title,
             'show_title': self.context.show_title,
+            'rss_link_url': rss_link_url,
             'more_items_link_url': more_items_link_url,
             'more_items_link_label': more_items_link_label,
             'hide_empty_block':  self.context.hide_empty_block,

--- a/ftw/events/browser/templates/eventlistingblock.pt
+++ b/ftw/events/browser/templates/eventlistingblock.pt
@@ -35,13 +35,18 @@
         </ul>
 
         <tal:footer tal:define="more_items_link_url block_info/more_items_link_url;
-                                more_items_link_label block_info/more_items_link_label">
+                                more_items_link_label block_info/more_items_link_label;
+                                rss_url block_info/rss_link_url">
             <a class="event-listingblock-moreitemslink"
                tal:condition="more_items_link_url"
                title="More Items"
                i18n:attributes="title more_items_link_label"
                tal:attributes="href more_items_link_url"
                tal:content="more_items_link_label"/>
+            <a class="events-rss"
+               tal:condition="rss_url"
+               tal:attributes="href rss_url"
+               i18n:translate="">Subscribe to the RSS feed</a>
         </tal:footer>
 
     </tal:events>

--- a/ftw/events/browser/templates/events_rss.pt
+++ b/ftw/events/browser/templates/events_rss.pt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:tal="http://xml.zope.org/namespaces/tal"
+     xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel tal:define="items view/get_items">
+        <atom:link tal:attributes="href string:${view/context/absolute_url}/${view/__name__}"
+                   rel="self"
+                   type="application/rss+xml" />
+        <title tal:content="view/title" />
+        <tal:link tal:replace="structure view/link">link</tal:link>
+        <description tal:content="view/description" />
+        <item tal:repeat='item items'>
+            <title tal:content="item/Title" />
+            <tal:link tal:replace="structure python:view.get_item_link(item.getURL())">link</tal:link>
+            <description tal:content="item/Description" />
+            <guid tal:content="item/getURL" />
+            <pubDate tal:define="effective item/effective"
+                     tal:condition="effective"
+                     tal:content="effective/rfc822" />
+        </item>
+    </channel>
+</rss>

--- a/ftw/events/contents/eventlistingblock.py
+++ b/ftw/events/contents/eventlistingblock.py
@@ -166,6 +166,15 @@ class IEventListingBlockSchema(form.Schema):
         required=False,
     )
 
+    show_rss_link = schema.Bool(
+        title=_(u'label_show_rss_link',
+                default=u'Link to RSS feed'),
+        description=_(u'description_show_rss_link',
+                      default=u'Render a link to the RSS feed of the events.'),
+        default=False,
+        required=False,
+    )
+
     hide_empty_block = schema.Bool(
         title=_(u'label_hide_empty_block',
                 default=u'Hide empty block'),

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-02-02 12:42+0000\n"
+"POT-Creation-Date: 2018-02-02 12:43+0000\n"
 "PO-Revision-Date: 2016-10-18 11:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,6 +58,10 @@ msgstr "Veranstaltungens-Seiten auf Basis von Simplelayout."
 msgid "Provides fields for configuring a mopage trigger (ftw.publisher)."
 msgstr "Felder für die Konfiguration des Mopage Auslösers."
 
+#: ./ftw/events/browser/templates/eventlistingblock.pt:46
+msgid "Subscribe to the RSS feed"
+msgstr "RSS Feed abonnieren"
+
 #: ./ftw/events/profiles/default/types/ftw.events.EventListingBlock.xml
 msgid "The event listing block renders a configurable list of event pages."
 msgstr "Konfigurierbarer Block, welcher Veranstaltungen auflistet."
@@ -71,7 +75,7 @@ msgid "Where"
 msgstr "Wo"
 
 #. Default: "Hide the block if there are not events to be shown."
-#: ./ftw/events/contents/eventlistingblock.py:172
+#: ./ftw/events/contents/eventlistingblock.py:181
 msgid "description_hide_empty_block"
 msgstr "Der Block wird nicht angezeigt, wenn keine Veranstaltungen vorhanden sind."
 
@@ -95,13 +99,18 @@ msgstr "Wird nicht übersetzt."
 msgid "description_more_items_view_title"
 msgstr "Wird nicht übersetzt."
 
+#. Default: "Render a link to the RSS feed of the events."
+#: ./ftw/events/contents/eventlistingblock.py:172
+msgid "description_show_rss_link"
+msgstr "Einen Link zum RSS-Feed der Veranstaltungen anzeigen."
+
 #. Default: "Show title"
 #: ./ftw/events/contents/eventlistingblock.py:72
 msgid "event_listing_block_show_title_label"
 msgstr "Titel anzeigen"
 
 #. Default: "You cannot filter by path and current context at the same time."
-#: ./ftw/events/contents/eventlistingblock.py:183
+#: ./ftw/events/contents/eventlistingblock.py:192
 msgid "event_listing_config_current_context_and_path_error"
 msgstr "Es ist nicht möglich, gleichzeitig nach Pfad und aktuellem Bereich zu filtern."
 
@@ -216,7 +225,7 @@ msgid "label_feed_desc"
 msgstr "${title} - Veranstaltungs Feed"
 
 #. Default: "Hide empty block"
-#: ./ftw/events/contents/eventlistingblock.py:170
+#: ./ftw/events/contents/eventlistingblock.py:179
 msgid "label_hide_empty_block"
 msgstr "Leeren Block ausblenden"
 
@@ -265,14 +274,19 @@ msgstr "Label für den Link \"Weitere Einträge\""
 msgid "label_more_items_view_title"
 msgstr "Titel der View hinter dem Link \"Weitere Einträge\""
 
+#. Default: "Link to RSS feed"
+#: ./ftw/events/contents/eventlistingblock.py:170
+msgid "label_show_rss_link"
+msgstr "Link zum RSS Feed"
+
 #. Default: "Mopage trigger enabled"
 #: ./ftw/events/behaviors/mopage.py:35
 msgid "label_trigger_enabled"
 msgstr "Mopage Trigger aktiviert"
 
 #. Default: "More Items"
-#: ./ftw/events/browser/eventlistingblock.py:32
-#: ./ftw/events/browser/templates/eventlistingblock.pt:39
+#: ./ftw/events/browser/eventlistingblock.py:37
+#: ./ftw/events/browser/templates/eventlistingblock.pt:40
 msgid "more_items_link_label"
 msgstr "Weitere Einträge"
 

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-27 16:12+0000\n"
+"POT-Creation-Date: 2018-02-02 12:42+0000\n"
 "PO-Revision-Date: 2016-10-18 11:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -209,6 +209,11 @@ msgstr "ftw.events"
 #: ./ftw/events/contents/eventlistingblock.py:78
 msgid "label_exclude_past_events"
 msgstr "Vergangene Veranstaltungen nicht anzeigen"
+
+#. Default: "${title} - Events Feed"
+#: ./ftw/events/browser/eventlisting.py:86
+msgid "label_feed_desc"
+msgstr "${title} - Veranstaltungs Feed"
 
 #. Default: "Hide empty block"
 #: ./ftw/events/contents/eventlistingblock.py:170

--- a/ftw/events/locales/ftw.events.pot
+++ b/ftw/events/locales/ftw.events.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-02-02 12:42+0000\n"
+"POT-Creation-Date: 2018-02-02 12:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,6 +58,10 @@ msgstr ""
 msgid "Provides fields for configuring a mopage trigger (ftw.publisher)."
 msgstr ""
 
+#: ./ftw/events/browser/templates/eventlistingblock.pt:46
+msgid "Subscribe to the RSS feed"
+msgstr ""
+
 #: ./ftw/events/profiles/default/types/ftw.events.EventListingBlock.xml
 msgid "The event listing block renders a configurable list of event pages."
 msgstr ""
@@ -71,7 +75,7 @@ msgid "Where"
 msgstr ""
 
 #. Default: "Hide the block if there are not events to be shown."
-#: ./ftw/events/contents/eventlistingblock.py:172
+#: ./ftw/events/contents/eventlistingblock.py:181
 msgid "description_hide_empty_block"
 msgstr ""
 
@@ -95,13 +99,18 @@ msgstr ""
 msgid "description_more_items_view_title"
 msgstr ""
 
+#. Default: "Render a link to the RSS feed of the events."
+#: ./ftw/events/contents/eventlistingblock.py:172
+msgid "description_show_rss_link"
+msgstr ""
+
 #. Default: "Show title"
 #: ./ftw/events/contents/eventlistingblock.py:72
 msgid "event_listing_block_show_title_label"
 msgstr ""
 
 #. Default: "You cannot filter by path and current context at the same time."
-#: ./ftw/events/contents/eventlistingblock.py:183
+#: ./ftw/events/contents/eventlistingblock.py:192
 msgid "event_listing_config_current_context_and_path_error"
 msgstr ""
 
@@ -216,7 +225,7 @@ msgid "label_feed_desc"
 msgstr ""
 
 #. Default: "Hide empty block"
-#: ./ftw/events/contents/eventlistingblock.py:170
+#: ./ftw/events/contents/eventlistingblock.py:179
 msgid "label_hide_empty_block"
 msgstr ""
 
@@ -265,14 +274,19 @@ msgstr ""
 msgid "label_more_items_view_title"
 msgstr ""
 
+#. Default: "Link to RSS feed"
+#: ./ftw/events/contents/eventlistingblock.py:170
+msgid "label_show_rss_link"
+msgstr ""
+
 #. Default: "Mopage trigger enabled"
 #: ./ftw/events/behaviors/mopage.py:35
 msgid "label_trigger_enabled"
 msgstr ""
 
 #. Default: "More Items"
-#: ./ftw/events/browser/eventlistingblock.py:32
-#: ./ftw/events/browser/templates/eventlistingblock.pt:39
+#: ./ftw/events/browser/eventlistingblock.py:37
+#: ./ftw/events/browser/templates/eventlistingblock.pt:40
 msgid "more_items_link_label"
 msgstr ""
 

--- a/ftw/events/locales/ftw.events.pot
+++ b/ftw/events/locales/ftw.events.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-27 16:12+0000\n"
+"POT-Creation-Date: 2018-02-02 12:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -208,6 +208,11 @@ msgstr ""
 #. Default: "Exclude past events"
 #: ./ftw/events/contents/eventlistingblock.py:78
 msgid "label_exclude_past_events"
+msgstr ""
+
+#. Default: "${title} - Events Feed"
+#: ./ftw/events/browser/eventlisting.py:86
+msgid "label_feed_desc"
 msgstr ""
 
 #. Default: "Hide empty block"

--- a/ftw/events/resources/events-theming.scss
+++ b/ftw/events/resources/events-theming.scss
@@ -71,3 +71,9 @@ body.userrole-authenticated .portlet.SimplelayoutPortlet .ftw-events-eventlistin
   @include boxshadow(0 0 20px 0 $color-warning);
   display: block;
 }
+
+// Add RSS icon to rss link in eventlisting block
+.events-rss {
+  @extend .fa-icon;
+  @extend .fa-rss;
+}

--- a/ftw/events/tests/test_rss_view.py
+++ b/ftw/events/tests/test_rss_view.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from datetime import timedelta
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.events.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+import transaction
+
+
+class TestRssView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRssView, self).setUp()
+        self.grant('Manager')
+
+        self.event_folder = create(Builder('event folder')
+                                   .titled(u'events'))
+
+        self.event_folder.events.show_rss_link = True
+        transaction.commit()
+
+        # Both events have to be in the future, to achieve this we use the
+        # current time and add a few days using timedelta.
+        now = datetime.now()
+
+        self.event_1 = create(Builder('event page')
+                              .titled(u"An event")
+                              .having(description=u'This is a test event')
+                              .starting(now + timedelta(days=30))
+                              .ending(now + timedelta(days=30, hours=5))
+                              .within(self.event_folder))
+
+        self.event_2 = create(Builder('event page')
+                              .titled(u"A second event")
+                              .having(description=u'Another test event')
+                              .starting(now + timedelta(days=60))
+                              .ending(now + timedelta(days=60, hours=3))
+                              .within(self.event_folder))
+
+    @browsing
+    def test_rss_button_is_visible(self, browser):
+        browser.login().visit(self.event_folder)
+        link_to_rss = browser.css('.ftw-events-eventlistingblock .events-rss')
+
+        self.assertEqual(['Subscribe to the RSS feed'],
+                         link_to_rss.text)
+        self.assertEqual('http://nohost/plone/events/events/events_rss',
+                         link_to_rss.first.get('href'))
+
+    @browsing
+    def test_rss_feed_structure(self, browser):
+        browser.login().visit(self.event_folder.events, view='events_rss')
+
+        self.assertEqual('2.0',
+                         browser.css('rss').first.get('version'))
+        self.assertEqual(['http://nohost/plone/events/events/events_rss'],
+                         browser.css('rss channel > link').text)
+        self.assertEqual(['Events - Events Feed'],
+                         browser.css('rss channel > description').text)
+        self.assertEqual(['An event', 'A second event'],
+                         browser.css('rss item title').text)
+        self.assertEqual(['http://nohost/plone/events/an-event',
+                          'http://nohost/plone/events/a-second-event'],
+                         browser.css('rss channel item link').text)


### PR DESCRIPTION
Implement a new view `events_rss` which shows an rss feed of current events on the event listing block.
Now there is an option on the newslisting block to show the link to the rss feed.

![events](https://user-images.githubusercontent.com/16755391/30691529-4a71b692-9ec8-11e7-9701-e398c966c1be.gif)

closes #29 