### PR TITLE
Add collective.taskqueue to test dependencies

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
+- Add collective.taskqueue to test-dependencies [raphael-s]
+
 - Group fields of the event listing block into separate fieldsets for
   better user experience. [mbaechtold]
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 version = '1.6.3.dev0'
 
 tests_require = [
+    'collective.taskqueue',
     'ftw.builder',
     'ftw.chameleon',
     'ftw.events[mopage_publisher_receiver]',


### PR DESCRIPTION
Since `testing.py` of ftw.events depends on `collective.taskqueue` we should add it to the test-dependencies.

I had to add it to the dependencies in another project because I wanted to use the builders.