### PR TITLE
Enable "ics_view" on event folder.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enable "ics_view" on event folder, so a ICS file can be exported containing
+  all the events within the event folder. [mbaechtold]
 
 
 1.7.1 (2018-02-06)

--- a/ftw/events/browser/configure.zcml
+++ b/ftw/events/browser/configure.zcml
@@ -34,4 +34,11 @@
         permission="zope2.View"
         />
 
+    <browser:page
+        for="ftw.events.interfaces.IEventFolder"
+        name="ics_view"
+        class="plone.app.event.ical.exporter.EventsICal"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-02-02 12:43+0000\n"
+"POT-Creation-Date: 2018-11-02 07:33+0000\n"
 "PO-Revision-Date: 2016-10-18 11:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -214,6 +214,12 @@ msgstr "Kein Inhalt verfügbar."
 msgid "ftw.events"
 msgstr "ftw.events"
 
+#. Default: "Export an ICS file containing all events from the current context."
+#: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
+msgid "help_ical_export"
+msgstr ""
+
 #. Default: "Exclude past events"
 #: ./ftw/events/contents/eventlistingblock.py:78
 msgid "label_exclude_past_events"
@@ -299,6 +305,12 @@ msgstr "Veranstaltungen"
 #: ./ftw/events/contents/eventfolder.py:33
 msgid "title_default_eventlisting_block"
 msgstr "Veranstaltungen"
+
+#. Default: "Ical export"
+#: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
+msgid "title_ical_export"
+msgstr "ICS Export"
 
 #: ./ftw/events/viewlets/templates/event_details.pt:7
 msgid "title_ics_export"

--- a/ftw/events/locales/ftw.events.pot
+++ b/ftw/events/locales/ftw.events.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-02-02 12:43+0000\n"
+"POT-Creation-Date: 2018-11-02 07:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -214,6 +214,12 @@ msgstr ""
 msgid "ftw.events"
 msgstr ""
 
+#. Default: "Export an ICS file containing all events from the current context."
+#: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
+msgid "help_ical_export"
+msgstr ""
+
 #. Default: "Exclude past events"
 #: ./ftw/events/contents/eventlistingblock.py:78
 msgid "label_exclude_past_events"
@@ -298,6 +304,12 @@ msgstr ""
 #. Default: "Events"
 #: ./ftw/events/contents/eventfolder.py:33
 msgid "title_default_eventlisting_block"
+msgstr ""
+
+#. Default: "Ical export"
+#: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
+msgid "title_ical_export"
 msgstr ""
 
 #: ./ftw/events/viewlets/templates/event_details.pt:7

--- a/ftw/events/profiles/default/actions.xml
+++ b/ftw/events/profiles/default/actions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<object name="portal_actions"
+        meta_type="Plone Actions Tool"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <object name="object" meta_type="CMF Action Category">
+        <object name="ical_export_settings" meta_type="CMF Action" i18n:domain="ftw.events">
+            <property name="title" i18n:translate="title_ical_export">Ical export</property>
+            <property name="description" i18n:translate="help_ical_export">Export an ICS file containing all events from the current context.</property>
+            <property name="url_expr">string:${object_url}/ics_view</property>
+            <property name="icon_expr"></property>
+            <property name="available_expr">python:context.portal_type == 'ftw.events.EventFolder'</property>
+            <property name="visible">True</property>
+        </object>
+    </object>
+
+</object>

--- a/ftw/events/tests/test_ics_view.py
+++ b/ftw/events/tests/test_ics_view.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.events.tests import FunctionalTestCase
 from ftw.events.tests import RealFuncitionalTestCase
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.pages import editbar
 
 
 class TestIsICSView(RealFuncitionalTestCase):
@@ -31,3 +33,43 @@ class TestIsICSView(RealFuncitionalTestCase):
         self.assertIn('BEGIN:VEVENT', body)
         self.assertIn('END:VCALENDAR', body)
         self.assertIn('END:VEVENT', body)
+
+    @browsing
+    def test_ics_view_is_ics_on_eventfolder(self, browser):
+        browser.request_library = LIB_REQUESTS
+
+        # Create a second event within the event folder
+        create(Builder('event page')
+               .titled(u"Another Event")
+               .starting(datetime(2017, 1, 7, 15, 00))
+               .ending(datetime(2017, 1, 7, 20, 00))
+               .having(recurrence='RRULE:FREQ=DAILY;COUNT=4')
+               .within(self.folder))
+
+        browser.login().visit(self.folder, view="ics_view")
+
+        body = browser.contents
+
+        self.assertIn('BEGIN:VCALENDAR', body)
+        self.assertIn('END:VCALENDAR', body)
+
+        # Both events are in the file.
+        self.assertEqual(2, body.count("BEGIN:VEVENT"))
+        self.assertIn('SUMMARY:A Event', body)
+        self.assertIn('SUMMARY:Another Event', body)
+
+
+class TestICSView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestICSView, self).setUp()
+        self.grant('Manager')
+
+    @browsing
+    def test_export_action_on_eventfolder(self, browser):
+        event_folder = create(Builder('event folder').titled(u'Activities'))
+        browser.login().visit(event_folder)
+        self.assertEqual(
+            'http://nohost/plone/activities/ics_view',
+            editbar.contentview('Ical export').attrib['href']
+        )

--- a/ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
+++ b/ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<object name="portal_actions"
+        meta_type="Plone Actions Tool"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <object name="object" meta_type="CMF Action Category">
+        <object name="ical_export_settings" meta_type="CMF Action" i18n:domain="ftw.events">
+            <property name="title" i18n:translate="title_ical_export">Ical export</property>
+            <property name="description" i18n:translate="help_ical_export">Export an ICS file containing all events from the current context.</property>
+            <property name="url_expr">string:${object_url}/ics_view</property>
+            <property name="icon_expr"></property>
+            <property name="available_expr">python:context.portal_type == 'ftw.events.EventFolder'</property>
+            <property name="visible">True</property>
+        </object>
+    </object>
+
+</object>

--- a/ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/upgrade.py
+++ b/ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddObjectActionForExportingICSFile(UpgradeStep):
+    """Add object action for exporting ICS file.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This allows a user to download an ics file of all the events within the event folder.

<img width="1183" alt="image" src="https://user-images.githubusercontent.com/28220/47899529-1e44c580-de7a-11e8-8605-a1af86b881db.png">
