### PR TITLE
Add arrow to 'more'-button

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add arrow in front of "more"-button, to create a similar appearance as
+  in ftw.news. [busykoala]
 
 
 1.8.0 (2018-11-05)

--- a/ftw/events/resources/events-theming.scss
+++ b/ftw/events/resources/events-theming.scss
@@ -2,6 +2,11 @@
 @include portal-type-font-awesome-icon(ftw-events-eventpage, calendar-o);
 @include portal-type-font-awesome-icon(ftw-events-eventlistingblock, calendar-o);
 
+.event-listingblock-moreitemslink {
+  @extend .fa-icon;
+  @extend .fa-caret-right;
+  display: block;
+}
 
 .event-details {
   .when {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29920936/49462050-6f3b3700-f7f5-11e8-8e85-358b1b270c38.png)


To create a similar appearance as in ftw.news this change adds
an arrow in front of the 'more'-button as there i one in front
of it in ftw.news.