### PR TITLE
Event archiv portlet

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add event archive portlet [Nachtalb]
 
 
 1.10.0 (2019-05-01)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,7 @@ Changelog
 -------------------
 
 - Add event archive portlet [Nachtalb]
-
+- Add missing plone 5 registry.xml records (previously plone 4 propertiestool.xml) [Nachtalb]
 
 1.10.0 (2019-05-01)
 -------------------

--- a/ftw/events/browser/configure.zcml
+++ b/ftw/events/browser/configure.zcml
@@ -49,4 +49,13 @@
         permission="zope2.View"
         />
 
+    <include package="plone.app.contentmenu" />
+    <browser:menuItem
+        for="ftw.events.interfaces.IEventFolder"
+        title="Event Listing"
+        description="Display the contents of a event folder."
+        menu="plone_displayviews"
+        action="event_listing"
+        />
+
 </configure>

--- a/ftw/events/browser/eventlisting.py
+++ b/ftw/events/browser/eventlisting.py
@@ -1,5 +1,4 @@
-from Products.CMFCore.permissions import AccessInactivePortalContent
-from Products.CMFCore.utils import getToolByName, _checkPermission
+from DateTime import DateTime
 from Products.CMFPlone.PloneBatch import Batch
 from Products.Five.browser import BrowserView
 from ftw.events import _
@@ -34,8 +33,25 @@ class EventListing(BrowserView):
             context=self.context,
             request=self.request,
         )
-        start, end = block_view.get_dates_for_query()
+
+        datestring = self.request.get('archive')
+        if datestring:
+            try:
+                start = DateTime(datestring)
+            except DateTime.interfaces.SyntaxError:
+                raise
+            end = DateTime('{0}/{1}/{2}'.format(
+                start.year() + start.month() / 12,
+                start.month() % 12 + 1,
+                1)
+            ) - 1
+
+            start = start.earliestTime()
+            end = end.latestTime()
+        else:
+            start, end = block_view.get_dates_for_query()
         block_query = block_view.get_query(start, end)
+
         return block_query
 
     def get_items(self):

--- a/ftw/events/browser/eventlisting.py
+++ b/ftw/events/browser/eventlisting.py
@@ -12,6 +12,8 @@ from zope.interface import implements
 
 class EventListing(BrowserView):
     """
+    EventListingBlock event listing
+
     This browser view renders a list of event pages based on the parameters
     defined on the event listing block which renders a link to this browser
     view.
@@ -98,6 +100,12 @@ class EventListing(BrowserView):
 
 
 class EventListingRss(EventListing):
+    """
+    RSS-Feed event listing
+
+    This view is to be called on an EventListingBlock and does takes its
+    parameters into account.
+    """
 
     @property
     def description(self):
@@ -115,6 +123,14 @@ class EventListingRss(EventListing):
 
 
 class EventListingFolder(EventListing):
+    """
+    EventFolder event listing
+
+    This event listing view is a simpler stripped down version of the
+    EventListingBlockEventListing. It is used on the EventFolder directly and
+    it does not take any EventListingBlock's parameters into account.
+    """
+
     @property
     def title(self):
         return self.context.Title()

--- a/ftw/events/browser/eventlisting.py
+++ b/ftw/events/browser/eventlisting.py
@@ -98,6 +98,10 @@ class EventListing(BrowserView):
         )
         return self.context.more_items_view_title or fallback_title
 
+    @property
+    def description(self):
+        return ''
+
 
 class EventListingRss(EventListing):
     """
@@ -134,6 +138,10 @@ class EventListingFolder(EventListing):
     @property
     def title(self):
         return self.context.Title()
+
+    @property
+    def description(self):
+        return self.context.description
 
     def get_query(self):
         query = {

--- a/ftw/events/browser/templates/eventlisting.pt
+++ b/ftw/events/browser/templates/eventlisting.pt
@@ -10,8 +10,10 @@
     </metal:title>
 
     <metal:description fill-slot="content-description">
-        <metal:comment tal:content="nothing">
-            No description
+        <metal:comment>
+            <div class="documentDescription description"
+                 tal:condition="view/description"
+                 tal:content="view/description" />
         </metal:comment>
     </metal:description>
 

--- a/ftw/events/configure.zcml
+++ b/ftw/events/configure.zcml
@@ -18,6 +18,7 @@
     <include package=".viewlets" />
     <include package=".browser" />
     <include package=".behaviors" />
+    <include package=".portlets" />
 
     <utility
         component=".vocabularies.SubjectVocabulary"

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-02 07:33+0000\n"
+"POT-Creation-Date: 2019-05-01 19:16+0000\n"
 "PO-Revision-Date: 2016-10-18 11:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,10 +19,12 @@ msgid "Allows to export the event to a calendar app"
 msgstr "Exportiert die Veranstaltung für eine externe Kalenderapplikation"
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventFolder.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
 msgid "Event Folder"
 msgstr "Veranstaltungsordner"
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventPage.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml
 msgid "Event Page"
 msgstr "Veranstaltung"
 
@@ -31,6 +33,7 @@ msgid "Event location"
 msgstr "Veranstaltungsort"
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventListingBlock.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
 msgid "EventListingBlock"
 msgstr "Auflistung von Veranstaltungen"
 
@@ -42,7 +45,7 @@ msgstr "ICS Export"
 msgid "Location fields for event pages."
 msgstr "Felder für Veranstaltungsort."
 
-#: ./ftw/events/behaviors/mopage.py:27
+#: ./ftw/events/behaviors/mopage.py:29
 msgid "Mopage"
 msgstr "Mopage"
 
@@ -50,7 +53,7 @@ msgstr "Mopage"
 msgid "Mopage trigger configuration"
 msgstr "Mopage auslöser konfiguration"
 
-#: ./ftw/events/profiles.zcml:16
+#: ./ftw/events/profiles.zcml:17
 msgid "Provides event pages based on simplelayout."
 msgstr "Veranstaltungens-Seiten auf Basis von Simplelayout."
 
@@ -63,6 +66,7 @@ msgid "Subscribe to the RSS feed"
 msgstr "RSS Feed abonnieren"
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventListingBlock.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
 msgid "The event listing block renders a configurable list of event pages."
 msgstr "Konfigurierbarer Block, welcher Veranstaltungen auflistet."
 
@@ -80,12 +84,12 @@ msgid "description_hide_empty_block"
 msgstr "Der Block wird nicht angezeigt, wenn keine Veranstaltungen vorhanden sind."
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.events.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/events/mopage.events.xml?partnerid=3&importid=6"
-#: ./ftw/events/behaviors/mopage.py:64
+#: ./ftw/events/behaviors/mopage.py:66
 msgid "description_mopage_data_endpoint_url"
 msgstr "Die Mopage Endpoint-URL zeigt auf die \"mopage.events.xml\"-Ansicht eines Events-Ordners auf Plone. Die URL muss die Parameter \"partnerid\" und \"importid\" enthalten. Die URL muss vollständig sein und auf die öffentliche Seite zeigen. Beispiel: https://mypage.ch/events/mopage.events.xml?partnerid=3&importid=6"
 
 #. Default: "Contains the mopage URL to the trigger endpoint. This is only the base URL, it does not contain the endpoint URL from which the mopage server retrieves the events. Example: https://un:pw@xml.mopage.ch/infoservice/xml.php"
-#: ./ftw/events/behaviors/mopage.py:46
+#: ./ftw/events/behaviors/mopage.py:48
 msgid "description_mopage_trigger_url"
 msgstr "Die Trigger-URL zeigt auf die Mopage-API. Sie enthält kein \"?url\"-Parameter, dieser wird automatisch angefügt. Beispiel: https://un:pw@xml.mopage.ch/infoservice/xml.php"
 
@@ -205,17 +209,18 @@ msgid "eventlisting_hide_empty_block_text"
 msgstr "Dieser Block ist nur noch für Benutzer sichtbar, die Inhalte bearbeiten dürfen. So kann der Block weiterhin bearbeitet werden."
 
 #. Default: "No content available."
-#: ./ftw/events/browser/templates/eventlisting.pt:20
+#: ./ftw/events/browser/templates/eventlisting.pt:22
 #: ./ftw/events/browser/templates/eventlistingblock.pt:14
 msgid "eventlisting_no_content_text"
 msgstr "Kein Inhalt verfügbar."
 
-#: ./ftw/events/profiles.zcml:16
+#: ./ftw/events/profiles.zcml:17
 msgid "ftw.events"
 msgstr "ftw.events"
 
 #. Default: "Export an ICS file containing all events from the current context."
 #: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/profiles/default_plone5/actions.xml
 #: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
 msgid "help_ical_export"
 msgstr ""
@@ -226,7 +231,7 @@ msgid "label_exclude_past_events"
 msgstr "Vergangene Veranstaltungen nicht anzeigen"
 
 #. Default: "${title} - Events Feed"
-#: ./ftw/events/browser/eventlisting.py:86
+#: ./ftw/events/browser/eventlisting.py:118
 msgid "label_feed_desc"
 msgstr "${title} - Veranstaltungs Feed"
 
@@ -261,12 +266,12 @@ msgid "label_location_zip"
 msgstr "Veranstaltungsort: PLZ"
 
 #. Default: "Mopage data endpoint URL (Plone)"
-#: ./ftw/events/behaviors/mopage.py:62
+#: ./ftw/events/behaviors/mopage.py:64
 msgid "label_mopage_data_endpoint_url"
 msgstr "Mopage: URL zu Daten-Endpoint"
 
 #. Default: "Mopage trigger URL"
-#: ./ftw/events/behaviors/mopage.py:44
+#: ./ftw/events/behaviors/mopage.py:46
 msgid "label_mopage_trigger_url"
 msgstr "Mopage Trigger URL"
 
@@ -286,7 +291,7 @@ msgid "label_show_rss_link"
 msgstr "Link zum RSS Feed"
 
 #. Default: "Mopage trigger enabled"
-#: ./ftw/events/behaviors/mopage.py:35
+#: ./ftw/events/behaviors/mopage.py:37
 msgid "label_trigger_enabled"
 msgstr "Mopage Trigger aktiviert"
 
@@ -297,7 +302,7 @@ msgid "more_items_link_label"
 msgstr "Weitere Einträge"
 
 #. Default: "Events"
-#: ./ftw/events/browser/eventlisting.py:76
+#: ./ftw/events/browser/eventlisting.py:98
 msgid "more_items_view_fallback_title"
 msgstr "Veranstaltungen"
 
@@ -308,6 +313,7 @@ msgstr "Veranstaltungen"
 
 #. Default: "Ical export"
 #: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/profiles/default_plone5/actions.xml
 #: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
 msgid "title_ical_export"
 msgstr "ICS Export"

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-01 19:16+0000\n"
+"POT-Creation-Date: 2019-05-01 19:20+0000\n"
 "PO-Revision-Date: 2016-10-18 11:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,10 +18,18 @@ msgstr ""
 msgid "Allows to export the event to a calendar app"
 msgstr "Exportiert die Veranstaltung für eine externe Kalenderapplikation"
 
+#: ./ftw/events/browser/configure.zcml:59
+msgid "Display the contents of a event folder."
+msgstr "Zeigt den Inhalt eines Veranstaltungsordner an."
+
 #: ./ftw/events/profiles/default/types/ftw.events.EventFolder.xml
 #: ./ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
 msgid "Event Folder"
 msgstr "Veranstaltungsordner"
+
+#: ./ftw/events/browser/configure.zcml:59
+msgid "Event Listing"
+msgstr "Veranstalgungsauflistung"
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventPage.xml
 #: ./ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml

--- a/ftw/events/locales/ftw.events.pot
+++ b/ftw/events/locales/ftw.events.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-02 07:33+0000\n"
+"POT-Creation-Date: 2019-05-01 19:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,10 +19,12 @@ msgid "Allows to export the event to a calendar app"
 msgstr ""
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventFolder.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
 msgid "Event Folder"
 msgstr ""
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventPage.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml
 msgid "Event Page"
 msgstr ""
 
@@ -31,6 +33,7 @@ msgid "Event location"
 msgstr ""
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventListingBlock.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
 msgid "EventListingBlock"
 msgstr ""
 
@@ -42,7 +45,7 @@ msgstr ""
 msgid "Location fields for event pages."
 msgstr ""
 
-#: ./ftw/events/behaviors/mopage.py:27
+#: ./ftw/events/behaviors/mopage.py:29
 msgid "Mopage"
 msgstr ""
 
@@ -50,7 +53,7 @@ msgstr ""
 msgid "Mopage trigger configuration"
 msgstr ""
 
-#: ./ftw/events/profiles.zcml:16
+#: ./ftw/events/profiles.zcml:17
 msgid "Provides event pages based on simplelayout."
 msgstr ""
 
@@ -63,6 +66,7 @@ msgid "Subscribe to the RSS feed"
 msgstr ""
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventListingBlock.xml
+#: ./ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
 msgid "The event listing block renders a configurable list of event pages."
 msgstr ""
 
@@ -80,12 +84,12 @@ msgid "description_hide_empty_block"
 msgstr ""
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.events.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/events/mopage.events.xml?partnerid=3&importid=6"
-#: ./ftw/events/behaviors/mopage.py:64
+#: ./ftw/events/behaviors/mopage.py:66
 msgid "description_mopage_data_endpoint_url"
 msgstr ""
 
 #. Default: "Contains the mopage URL to the trigger endpoint. This is only the base URL, it does not contain the endpoint URL from which the mopage server retrieves the events. Example: https://un:pw@xml.mopage.ch/infoservice/xml.php"
-#: ./ftw/events/behaviors/mopage.py:46
+#: ./ftw/events/behaviors/mopage.py:48
 msgid "description_mopage_trigger_url"
 msgstr ""
 
@@ -205,17 +209,18 @@ msgid "eventlisting_hide_empty_block_text"
 msgstr ""
 
 #. Default: "No content available."
-#: ./ftw/events/browser/templates/eventlisting.pt:20
+#: ./ftw/events/browser/templates/eventlisting.pt:22
 #: ./ftw/events/browser/templates/eventlistingblock.pt:14
 msgid "eventlisting_no_content_text"
 msgstr ""
 
-#: ./ftw/events/profiles.zcml:16
+#: ./ftw/events/profiles.zcml:17
 msgid "ftw.events"
 msgstr ""
 
 #. Default: "Export an ICS file containing all events from the current context."
 #: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/profiles/default_plone5/actions.xml
 #: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
 msgid "help_ical_export"
 msgstr ""
@@ -226,7 +231,7 @@ msgid "label_exclude_past_events"
 msgstr ""
 
 #. Default: "${title} - Events Feed"
-#: ./ftw/events/browser/eventlisting.py:86
+#: ./ftw/events/browser/eventlisting.py:118
 msgid "label_feed_desc"
 msgstr ""
 
@@ -261,12 +266,12 @@ msgid "label_location_zip"
 msgstr ""
 
 #. Default: "Mopage data endpoint URL (Plone)"
-#: ./ftw/events/behaviors/mopage.py:62
+#: ./ftw/events/behaviors/mopage.py:64
 msgid "label_mopage_data_endpoint_url"
 msgstr ""
 
 #. Default: "Mopage trigger URL"
-#: ./ftw/events/behaviors/mopage.py:44
+#: ./ftw/events/behaviors/mopage.py:46
 msgid "label_mopage_trigger_url"
 msgstr ""
 
@@ -286,7 +291,7 @@ msgid "label_show_rss_link"
 msgstr ""
 
 #. Default: "Mopage trigger enabled"
-#: ./ftw/events/behaviors/mopage.py:35
+#: ./ftw/events/behaviors/mopage.py:37
 msgid "label_trigger_enabled"
 msgstr ""
 
@@ -297,7 +302,7 @@ msgid "more_items_link_label"
 msgstr ""
 
 #. Default: "Events"
-#: ./ftw/events/browser/eventlisting.py:76
+#: ./ftw/events/browser/eventlisting.py:98
 msgid "more_items_view_fallback_title"
 msgstr ""
 
@@ -308,6 +313,7 @@ msgstr ""
 
 #. Default: "Ical export"
 #: ./ftw/events/profiles/default/actions.xml
+#: ./ftw/events/profiles/default_plone5/actions.xml
 #: ./ftw/events/upgrades/20181031165317_add_object_action_for_exporting_ics_file/actions.xml
 msgid "title_ical_export"
 msgstr ""

--- a/ftw/events/locales/ftw.events.pot
+++ b/ftw/events/locales/ftw.events.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-01 19:16+0000\n"
+"POT-Creation-Date: 2019-05-01 19:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,9 +18,17 @@ msgstr ""
 msgid "Allows to export the event to a calendar app"
 msgstr ""
 
+#: ./ftw/events/browser/configure.zcml:59
+msgid "Display the contents of a event folder."
+msgstr ""
+
 #: ./ftw/events/profiles/default/types/ftw.events.EventFolder.xml
 #: ./ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
 msgid "Event Folder"
+msgstr ""
+
+#: ./ftw/events/browser/configure.zcml:59
+msgid "Event Listing"
 msgstr ""
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventPage.xml

--- a/ftw/events/portlets/configure.zcml
+++ b/ftw/events/portlets/configure.zcml
@@ -1,0 +1,19 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    i18n_domain="ftw.news">
+
+    <include package="plone.app.portlets" />
+
+
+    <plone:portlet
+        name="eventsarchiveportlet"
+        interface=".events_archive_portlet.IEventsArchivePortlet"
+        assignment=".events_archive_portlet.Assignment"
+        view_permission="zope2.View"
+        renderer=".events_archive_portlet.Renderer"
+        addview=".events_archive_portlet.AddForm"
+        />
+
+</configure>

--- a/ftw/events/portlets/events_archive_portlet.py
+++ b/ftw/events/portlets/events_archive_portlet.py
@@ -1,0 +1,200 @@
+from DateTime import DateTime
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.i18nl10n import monthname_msgid
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.app.portlets.portlets import base
+from plone.memoize.view import memoize
+from plone.portlets.interfaces import IPortletDataProvider
+from zope.i18n import translate
+from zope.interface import implements
+
+from ftw.events.interfaces import IEventPage, IEventListingView
+
+
+def zLocalizedTime(request, time, long_format=False):
+    """Convert time to localized time
+    """
+    month_msgid = monthname_msgid(time.strftime('%m'))
+    month = translate(month_msgid, domain='plonelocales',
+                      context=request)
+
+    return month.encode('utf-8')
+
+
+class ArchiveSummary(object):
+
+    def __init__(self, context, request, interfaces, date_field, view):
+        self.context = context
+        self.request = request
+        self.interfaces = interfaces
+        self.date_field = date_field
+        self.view = view
+        self.selected_year = None
+        self.selected_month = None
+
+    def __call__(self):
+        self._set_selected_archive()
+
+        entries = self._get_archive_entries()
+        counter = self._count_entries(entries)
+
+        result = []
+        year_numbers = sorted(counter, reverse=True)
+
+        for year_number in year_numbers:
+
+            year = counter.get(year_number)
+            months = year.get('months')
+            month_numbers = sorted(months, reverse=True)
+            month_list = []
+
+            for month_number in month_numbers:
+                date = '%s/%s/01' % (year_number, month_number)
+
+                month_list.append(dict(
+                    title=zLocalizedTime(self.request, DateTime(date)),
+                    number=months.get(month_number),
+                    url=self._get_archive_url(date),
+                    mark=[self.selected_year, self.selected_month] == [
+                        year_number, month_number]
+                ))
+
+            result.append(dict(
+                title=year_number,
+                number=year.get('num'),
+                months=month_list,
+                mark=self.selected_year == year_number
+            ))
+
+        return result
+
+    def _set_selected_archive(self):
+        selected_archive = self.request.get('archive')
+        if selected_archive:
+            self.selected_year = selected_archive.split('/')[0]
+            self.selected_month = selected_archive.split('/')[1]
+
+    def _get_archive_url(self, date):
+        url = '{url}/{view}?archive={date}'.format(
+            url=self.context.absolute_url(),
+            view=self.view.__name__,
+            date=date)
+
+        portlet = self.request.get('portlet', None)
+        manager = self.request.get('manager', None)
+        if portlet:
+            url += '&portlet={0}'.format(portlet)
+        if manager:
+            url += '&manager={0}'.format(manager)
+
+        return url
+
+    def _get_archive_entries(self):
+        catalog = getToolByName(self.context, 'portal_catalog')
+        query = self._get_query()
+        if 'start' in query:
+            del query['start']
+        if 'end' in query:
+            del query['end']
+        return catalog(**query)
+
+    def _get_query(self):
+        return self.view.get_query()
+
+    def _count_entries(self, entries):
+        """Return a summary map like:
+
+        {'2009': {
+            'num': 6,
+            'months': {
+                '01': 4,
+                '02': 2}
+            }
+        }
+        """
+        summary = {}
+
+        for entry in entries:
+
+            date = getattr(entry, self.date_field)
+            if not date:
+                continue
+
+            year_name = date.strftime('%Y')
+            month_name = date.strftime('%m')
+
+            year_summary = summary.get(year_name, {})
+            month_summary = year_summary.get('months', {})
+
+            # Increase month
+            month_summary.update(
+                {month_name: month_summary.get(month_name, 0) + 1})
+            year_summary.update({'months': month_summary})
+
+            # Increase year
+            year_summary.update({'num': year_summary.get('num', 0) + 1})
+            summary.update({year_name: year_summary})
+
+        return summary
+
+
+class IEventsArchivePortlet(IPortletDataProvider):
+    """Archive portlet interface.
+    """
+
+
+class Assignment(base.Assignment):
+    implements(IEventsArchivePortlet)
+
+    @property
+    def title(self):
+        return 'Events Archive Portlet'
+
+
+class Renderer(base.Renderer):
+    def __init__(self, context, request, view, manager, data):
+        self.context = context
+        self.data = data
+        self.request = request
+        self.view = view
+
+    @property
+    def available(self):
+        """Show the portlet only if we're on a news listing view and
+        there is some content to be displayed.
+        """
+        is_event_listing_view = IEventListingView.providedBy(self.view)
+        return is_event_listing_view and bool(self.get_items())
+
+    @memoize
+    def get_items(self):
+        """Returns an ordered list of summary info per month."""
+        summary = ArchiveSummary(
+            context=self.context,
+            request=self.request,
+            interfaces=[IEventPage.__identifier__],
+            date_field='start',
+            view=self.view)()
+
+        items = [{
+            'title': year['title'],
+            'count': year['number'],
+            'class': 'year expanded' if year['mark'] else 'year',
+            'months_expanded': 'months expanded' if year['mark'] else 'months',
+            'months': [{
+                'title': month['title'],
+                'url': month['url'],
+                'class': 'month highlight' if month['mark'] else 'month',
+                'month': month['title'],
+                'count': month['number'],
+            } for month in year['months']],
+        } for year in summary]
+        return items
+
+    render = ViewPageTemplateFile('templates/events_archive_portlet.pt')
+
+
+class AddForm(base.NullAddForm):
+
+    def create(self):
+        return Assignment()

--- a/ftw/events/portlets/templates/events_archive_portlet.pt
+++ b/ftw/events/portlets/templates/events_archive_portlet.pt
@@ -1,0 +1,44 @@
+<html xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="python: 1"
+      i18n:domain="ftw.news">
+
+    <section class="portlet archive-portlet">
+
+        <header class="portletHeader">
+            <h2 i18n:translate="">Archive</h2>
+        </header>
+        <section class="portletItem">
+          <ul class="years">
+              <li tal:repeat="year view/get_items">
+
+                  <a href="#"
+                     tal:attributes="class year/class;
+                                     aria-controls string:year_${year/title}"
+                     aria-haspopup="true">
+                     <span class="title" tal:content="year/title"></span>
+                     <span class="count"
+                           tal:content="year/count"
+                           tal:condition="year/count"></span>
+                  </a>
+
+                  <ul tal:attributes="class year/months_expanded;
+                                      id string:year_${year/title}"
+                      aria-hidden="true">
+                      <li tal:repeat="month year/months">
+                          <a tal:attributes="href month/url;
+                                             title month/title;
+                                             class month/class"
+                             i18n:translate="">
+                             <span class="title" tal:content="month/title"></span>
+                             <span class="count"
+                                   tal:content="month/count"
+                                   tal:condition="month/count"></span>
+                          </a>
+                      </li>
+                  </ul>
+              </li>
+          </ul>
+        </section>
+    </section>
+</html>

--- a/ftw/events/profiles.zcml
+++ b/ftw/events/profiles.zcml
@@ -1,17 +1,27 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     i18n_domain="ftw.events">
 
-    <include package="ftw.upgrade" />
+    <include package="ftw.upgrade"/>
 
     <genericsetup:registerProfile
+        zcml:condition="not-have plone-5"
         name="default"
         title="ftw.events"
         description="Provides event pages based on simplelayout."
         directory="profiles/default"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="default"
+        title="ftw.events"
+        description="Provides event pages based on simplelayout."
+        directory="profiles/default_plone5"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 

--- a/ftw/events/profiles/default/jsregistry.xml
+++ b/ftw/events/profiles/default/jsregistry.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry"
+        autogroup="False">
+
+    <javascript cacheable="True"
+                compression="safe"
+                cookable="True"
+                enabled="True"
+                expression=""
+                id="++resource++ftw.events.resources/event-archive-portlet.js"
+                inline="False"/>
+
+</object>

--- a/ftw/events/profiles/default/portlets.xml
+++ b/ftw/events/profiles/default/portlets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<portlets>
+
+    <portlet
+        addview="eventsarchiveportlet"
+        title="Events Archive Portlet (ftw.events)"
+        description=""
+        />
+
+</portlets>

--- a/ftw/events/profiles/default_plone5/actions.xml
+++ b/ftw/events/profiles/default_plone5/actions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<object name="portal_actions"
+        meta_type="Plone Actions Tool"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <object name="object" meta_type="CMF Action Category">
+        <object name="ical_export_settings" meta_type="CMF Action" i18n:domain="ftw.events">
+            <property name="title" i18n:translate="title_ical_export">Ical export</property>
+            <property name="description" i18n:translate="help_ical_export">Export an ICS file containing all events from the current context.</property>
+            <property name="url_expr">string:${object_url}/ics_view</property>
+            <property name="icon_expr"></property>
+            <property name="available_expr">python:context.portal_type == 'ftw.events.EventFolder'</property>
+            <property name="visible">True</property>
+        </object>
+    </object>
+
+</object>

--- a/ftw/events/profiles/default_plone5/browserlayer.xml
+++ b/ftw/events/profiles/default_plone5/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+    <layer name="ftw.events"
+           interface="ftw.events.interfaces.IFTWEventsLayer" />
+
+</layers>

--- a/ftw/events/profiles/default_plone5/metadata.xml
+++ b/ftw/events/profiles/default_plone5/metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<metadata>
+    <dependencies>
+        <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
+        <dependency>profile-plone.app.event:default</dependency>
+        <dependency>profile-plone.app.referenceablebehavior:default</dependency>
+        <dependency>profile-ftw.referencewidget:default</dependency>
+        <dependency>profile-ftw.keywordwidget:default</dependency>
+    </dependencies>
+</metadata>

--- a/ftw/events/profiles/default_plone5/metadata.xml
+++ b/ftw/events/profiles/default_plone5/metadata.xml
@@ -3,7 +3,6 @@
     <dependencies>
         <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
         <dependency>profile-plone.app.event:default</dependency>
-        <dependency>profile-plone.app.referenceablebehavior:default</dependency>
         <dependency>profile-ftw.referencewidget:default</dependency>
         <dependency>profile-ftw.keywordwidget:default</dependency>
     </dependencies>

--- a/ftw/events/profiles/default_plone5/portlets.xml
+++ b/ftw/events/profiles/default_plone5/portlets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<portlets>
+
+    <portlet
+        addview="eventsarchiveportlet"
+        title="Events Archive Portlet (ftw.events)"
+        description=""
+        />
+
+</portlets>

--- a/ftw/events/profiles/default_plone5/registry.xml
+++ b/ftw/events/profiles/default_plone5/registry.xml
@@ -1,0 +1,17 @@
+<registry>
+
+  <record name="plone.types_not_searched"
+          interface="Products.CMFPlone.interfaces.controlpanel.ISearchSchema"
+          field="types_not_searched">
+    <value>
+      <element>ftw.events.EventListingBlock</element>
+    </value>
+  </record>
+
+  <record name="plone.displayed_types">
+    <value purge="false">
+      <element>ftw.events.EventFolder</element>
+    </value>
+  </record>
+
+</registry>

--- a/ftw/events/profiles/default_plone5/rolemap.xml
+++ b/ftw/events/profiles/default_plone5/rolemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<rolemap>
+    <permissions>
+
+        <permission name="ftw.events: Add Event Folder" acquire="False">
+            <role name="Contributor"/>
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+        <permission name="ftw.events: Add Event Page" acquire="False">
+            <role name="Contributor"/>
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+        <permission name="ftw.events: Add EventListingBlock" acquire="False">
+            <role name="Contributor"/>
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+    </permissions>
+
+</rolemap>

--- a/ftw/events/profiles/default_plone5/tinymce.xml
+++ b/ftw/events/profiles/default_plone5/tinymce.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+        <linkable purge="False">
+            <element value="ftw.events.EventFolder"/>
+            <element value="ftw.events.EventPage"/>
+        </linkable>
+    </resourcetypes>
+</object>

--- a/ftw/events/profiles/default_plone5/tinymce.xml
+++ b/ftw/events/profiles/default_plone5/tinymce.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<object>
-    <resourcetypes>
-        <linkable purge="False">
-            <element value="ftw.events.EventFolder"/>
-            <element value="ftw.events.EventPage"/>
-        </linkable>
-    </resourcetypes>
-</object>

--- a/ftw/events/profiles/default_plone5/types.xml
+++ b/ftw/events/profiles/default_plone5/types.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+
+    <object name="ftw.events.EventFolder" meta_type="Dexterity FTI"/>
+    <object name="ftw.events.EventPage" meta_type="Dexterity FTI"/>
+    <object name="ftw.events.EventListingBlock" meta_type="Dexterity FTI"/>
+
+</object>

--- a/ftw/events/profiles/default_plone5/types/Plone_Site.xml
+++ b/ftw/events/profiles/default_plone5/types/Plone_Site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.events.EventFolder" />
+        <element value="ftw.events.EventListingBlock" />
+    </property>
+
+</object>

--- a/ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
+++ b/ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<object name="ftw.events.EventFolder"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.events" >
+
+    <property name="title" i18n:translate="">Event Folder</property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="ftw.events.EventPage" />
+        <element value="ftw.events.EventListingBlock" />
+        <element value="ftw.simplelayout.FileListingBlock" />
+        <element value="ftw.simplelayout.GalleryBlock" />
+        <element value="ftw.simplelayout.MapBlock" />
+        <element value="ftw.simplelayout.TextBlock" />
+        <element value="ftw.simplelayout.VideoBlock" />
+    </property>
+
+    <property name="schema">ftw.events.contents.eventfolder.IEventFolderSchema</property>
+    <property name="klass">ftw.events.contents.eventfolder.EventFolder</property>
+    <property name="add_permission">ftw.events.AddEventFolder</property>
+
+    <property name="behaviors">
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+    </property>
+
+    <property name="default_view">@@simplelayout-view</property>
+    <property name="view_methods">
+        <element value="simplelayout-view"/>
+        <element value="ftwcalendar_view"/>
+        <element value="event_listing"/>
+    </property>
+    <property name="default_view_fallback">False</property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)" />
+    <alias from="view" to="(selected layout)" />
+    <alias from="edit" to="@@edit" />
+    <alias from="sharing" to="@@sharing" />
+
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
+++ b/ftw/events/profiles/default_plone5/types/ftw.events.EventFolder.xml
@@ -27,7 +27,6 @@
         <element value="ftw.simplelayout.interfaces.ISimplelayout" />
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
-        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <property name="default_view">@@simplelayout-view</property>

--- a/ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
+++ b/ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<object name="ftw.events.EventListingBlock"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.events" >
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">EventListingBlock</property>
+    <property name="description" i18n:translate="">The event listing block renders a configurable list of event pages.</property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">False</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types"></property>
+
+    <!-- schema interface -->
+    <property name="schema">ftw.events.contents.eventlistingblock.IEventListingBlockSchema</property>
+
+    <!-- class used for content items -->
+    <property name="klass">ftw.events.contents.eventlistingblock.EventListingBlock</property>
+
+    <!-- add permission -->
+    <property name="add_permission">ftw.events.AddEventListingBlock</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+    </property>
+
+   <!-- View information -->
+   <property name="default_view">@@redirect_to_parent</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="@@redirect_to_parent"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+</object>

--- a/ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
+++ b/ftw/events/profiles/default_plone5/types/ftw.events.EventListingBlock.xml
@@ -26,7 +26,6 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
-        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
    <!-- View information -->

--- a/ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml
+++ b/ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<object name="ftw.events.EventPage"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.events" >
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">Event Page</property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">False</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="ftw.simplelayout.FileListingBlock" />
+        <element value="ftw.simplelayout.GalleryBlock" />
+        <element value="ftw.simplelayout.MapBlock" />
+        <element value="ftw.simplelayout.TextBlock" />
+        <element value="ftw.simplelayout.VideoBlock" />
+    </property>
+
+    <!-- schema interface -->
+    <property name="schema">ftw.events.contents.eventpage.IEventPageSchema</property>
+
+    <!-- class used for content items -->
+    <property name="klass">ftw.events.contents.eventpage.EventPage</property>
+
+    <!-- add permission -->
+    <property name="add_permission">ftw.events.AddEventPage</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+        <element value="plone.app.event.dx.behaviors.IEventBasic"/>
+        <element value="plone.app.event.dx.behaviors.IEventRecurrence"/>
+        <element value="ftw.keywordwidget.behavior.IKeywordCategorization" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+        <element value="ftw.events.behaviors.location.ILocationFields"/>
+    </property>
+
+    <!-- View information -->
+    <property name="default_view">@@simplelayout-view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="@@simplelayout-view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+    <!-- Actions -->
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml
+++ b/ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml
@@ -36,7 +36,6 @@
         <element value="plone.app.event.dx.behaviors.IEventBasic"/>
         <element value="plone.app.event.dx.behaviors.IEventRecurrence"/>
         <element value="ftw.keywordwidget.behavior.IKeywordCategorization" />
-        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
         <element value="ftw.events.behaviors.location.ILocationFields"/>
     </property>
 

--- a/ftw/events/profiles/default_plone5/types/ftw.simplelayout.ContentPage.xml
+++ b/ftw/events/profiles/default_plone5/types/ftw.simplelayout.ContentPage.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="ftw.simplelayout.ContentPage">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.events.EventFolder"/>
+        <element value="ftw.events.EventListingBlock"/>
+    </property>
+
+</object>

--- a/ftw/events/profiles/default_plone5/workflows.xml
+++ b/ftw/events/profiles/default_plone5/workflows.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+    <bindings>
+        <type type_id="ftw.events.EventListingBlock"/>
+    </bindings>
+
+</object>

--- a/ftw/events/resources.zcml
+++ b/ftw/events/resources.zcml
@@ -1,12 +1,19 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:theme="http://namespaces.zope.org/ftw.theming"
+    xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="ftw.events">
 
     <include package="ftw.theming" file="meta.zcml"/>
 
+    <browser:resourceDirectory
+        name="ftw.events.resources"
+        directory="resources"
+        />
+
     <theme:resources profile="ftw.events:default" slot="addon">
         <theme:scss file="resources/events-theming.scss" />
+        <theme:scss file="resources/event-archive-portlet.scss" />
     </theme:resources>
 
 </configure>

--- a/ftw/events/resources/event-archive-portlet.js
+++ b/ftw/events/resources/event-archive-portlet.js
@@ -1,0 +1,185 @@
+/*
+  This javascript file provides accessibility support for the archive portlet.
+
+  Controls on the year layer:
+
+  Right arrow: Opens the current selected year and selects the first month.
+  Left arrow: Closes the current opened year.
+  Down arrow: Selects the next year in the year list.
+  Up arrow: Selects the previous year in the year list.
+  Enter: Opens the current selected year and selects the first month.
+
+  Controls on the month layer:
+
+  Down arrow: Selects the next month in the month list.
+  Up arrow: Selects the previous month in the month list.
+  Left arrow: Closes the opened year and select the year.
+  Escape: Closes the opened year and select the year.
+
+ */
+
+(function() {
+
+  "use strict";
+
+  var element = $();
+
+  function openYear(year) { year.addClass("expanded"); }
+
+  function closeMonth(year) {
+    $(".months", year.parent()).attr("aria-hidden", "true");
+  }
+
+  function closeYear(year) {
+    year.removeClass("expanded");
+    closeMonth(year);
+    year.focus();
+  }
+
+  function toggleYear(year) {
+    year.toggleClass("expanded");
+    if(!year.hasClass("expanded")) {
+      year.focus();
+    }
+  }
+
+  function selectFirstMonth(year) {
+    $(".month", year.parent()).first().focus();
+    $(".months", year.parent()).attr("aria-hidden", "false");
+  }
+
+  var yearCarousel = {
+    currentIndex: 0,
+    years: $(".year"),
+    next: function() {
+      if(this.currentIndex === this.years.length - 1) {
+        this.currentIndex = 0;
+      } else {
+        this.currentIndex ++;
+      }
+      this.focus();
+    },
+    previous: function() {
+      if(this.currentIndex === 0) {
+        this.currentIndex = this.years.length - 1;
+      } else {
+        this.currentIndex --;
+      }
+      this.focus();
+    },
+    focus: function() {
+      this.years.eq(this.currentIndex).focus();
+    },
+    init: function(context) {
+      this.years = $(".year", context);
+      this.currentIndex = 0;
+    }
+  };
+
+  var monthCarousel = {
+    currentIndex: 0,
+    months: $(),
+    year: $(),
+    next: function() {
+      if(this.currentIndex === this.months.length - 1) {
+        this.currentIndex = 0;
+      } else {
+        this.currentIndex ++;
+      }
+      this.focus();
+    },
+    previous: function() {
+      if(this.currentIndex === 0) {
+        this.currentIndex = this.months.length - 1;
+      } else {
+        this.currentIndex --;
+      }
+      this.focus();
+    },
+    focus: function() {
+      this.months.eq(this.currentIndex).focus();
+    },
+    closeYear: function() {
+      closeYear(this.year);
+    },
+    init: function(year, index) {
+      this.year = year;
+      this.months = $(".month", this.year.parent());
+      this.currentIndex = index || 0;
+    }
+  };
+
+  $(document).on("click", ".year", function(event) {
+    event.preventDefault();
+    toggleYear($(event.currentTarget));
+  });
+
+  $(document).on("keydown", ".year", function(event) {
+    var year = $(event.currentTarget);
+    monthCarousel.init(year);
+
+    switch (event.which) {
+      case $.ui.keyCode.RIGHT:
+        event.preventDefault();
+        openYear(year);
+        selectFirstMonth(year);
+        break;
+      case $.ui.keyCode.LEFT:
+        event.preventDefault();
+        closeYear(year);
+        break;
+      case $.ui.keyCode.DOWN:
+        event.preventDefault();
+        yearCarousel.next();
+        break;
+      case $.ui.keyCode.UP:
+        event.preventDefault();
+        yearCarousel.previous();
+        break;
+      case $.ui.keyCode.ENTER:
+        event.preventDefault();
+        openYear(year);
+        selectFirstMonth(year);
+        break;
+    }
+  });
+
+  $(document).on("keydown", ".month", function(event) {
+    var month = $(event.currentTarget);
+
+    switch (event.which) {
+      case $.ui.keyCode.DOWN:
+        event.preventDefault();
+        monthCarousel.next(month);
+        break;
+      case $.ui.keyCode.UP:
+        event.preventDefault();
+        monthCarousel.previous(month);
+        break;
+      case $.ui.keyCode.LEFT:
+        event.preventDefault();
+        monthCarousel.closeYear();
+        break;
+      case $.ui.keyCode.ESCAPE:
+        event.preventDefault();
+        monthCarousel.closeYear();
+        break;
+    }
+  });
+
+  $(document).on("keyup", ".month", function(event) {
+    var month = $(event.currentTarget);
+
+    switch (event.which) {
+      case $.ui.keyCode.TAB:
+        monthCarousel.init(month.parents('.months').prev(), month.parent().index());
+        break;
+    }
+  });
+
+  $(function() {
+    element = $(".archive-portlet");
+    yearCarousel.init(element);
+  });
+
+}(window));

--- a/ftw/events/resources/event-archive-portlet.scss
+++ b/ftw/events/resources/event-archive-portlet.scss
@@ -1,0 +1,27 @@
+.archive-portlet {
+  ul {
+    @include list-tree($indentation: $line-height-base);
+  }
+
+  .count {
+    @include label-round();
+  }
+
+  .year {
+    @extend .fa-icon;
+    @extend .fa-angle-right;
+
+    &.expanded {
+      @extend .fa-icon;
+      @extend .fa-angle-down;
+
+      ~ .months {
+        display: block;
+      }
+    }
+  }
+
+  .months {
+    display: none;
+  }
+}

--- a/ftw/events/tests/test_event_archive_portlets.py
+++ b/ftw/events/tests/test_event_archive_portlets.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.events.testing import FUNCTIONAL_TESTING
+from ftw.events.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from plone import api
+import transaction
+
+events_portlet_action = '/++contextportlets++plone.rightcolumn/+/eventsarchiveportlet'
+
+
+class TestEventArchivePortlets(FunctionalTestCase):
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestEventArchivePortlets, self).setUp()
+        self.grant('Manager')
+
+    def _add_portlet(self, browser, context=None):
+        """
+        This helper method adds a events archive portlet on the given context.
+        If no context is provided then the portlet will be added on the
+        Plone site.
+        """
+        context = context or self.portal
+        browser.login().visit(context, view='@@manage-portlets')
+        browser.css('#portletmanager-plone-rightcolumn form')[0].fill(
+            {':action': events_portlet_action}).submit()
+        browser.open(context)
+
+    @browsing
+    def test_archive_portlet_available_when_there_are_events(self, browser):
+        events_folder = create(Builder('event folder').titled(u'Event Folder')
+                               .with_property('layout', 'event_listing'))
+        create(Builder('event page').titled(u'Event Entry').within(events_folder)
+               .with_property('layout', 'event_listing'))
+
+        self._add_portlet(browser, events_folder)
+
+        self.assertIn('Archive', browser.css('.archive-portlet header h2').text,
+                      'Archive portlet is not here but it should be.')
+
+    @browsing
+    def test_archive_portlet_not_available_when_empty(self, browser):
+        events_folder = create(Builder('event folder').titled(u'Event Folder')
+                               .with_property('layout', 'event_listing'))
+
+        self._add_portlet(browser, events_folder)
+
+        self.assertNotIn('Archive', browser.css('dt.portletHeader').text,
+                         'Archive portlet is here but it should not be.')
+
+    @browsing
+    def test_archive_portlet_summary(self, browser):
+        """
+        This test makes sure the summary is correct.
+        """
+        events_folder = create(Builder('event folder').titled(u'Event Folder')
+                               .with_property('layout', 'event_listing'))
+        create(Builder('event page').titled(u'Event Entry 1').within(events_folder)
+               .having(start=datetime(2013, 1, 1), end=datetime(2013, 1, 1)))
+        create(Builder('event page').titled(u'Event Entry 2').within(events_folder)
+               .having(start=datetime(2013, 1, 11), end=datetime(2013, 1, 11)))
+        create(Builder('event page').titled(u'Event Entry 3').within(events_folder)
+               .having(start=datetime(2013, 2, 2), end=datetime(2013, 2, 2)))
+
+        self._add_portlet(browser, events_folder)
+
+        self.assertEqual(
+            ['http://nohost/plone/event-folder/event_listing?archive=2013/02/01',
+                'http://nohost/plone/event-folder/event_listing?archive=2013/01/01'],
+            map(lambda month: month.attrib['href'], browser.css('.month')))
+
+    @browsing
+    def test_archive_portlet_not_available_on_plone_site(self, browser):
+        """
+        The events archive portlet is only rendered on events listing views.
+        """
+        events_folder = create(Builder('event folder').titled(u'Event Folder')
+                               .with_property('layout', 'event_listing'))
+        create(Builder('event page').titled(u'Event Entry 1').within(events_folder))
+
+        self._add_portlet(browser)
+        self.assertNotIn('Archive', browser.css('dt.portletHeader').text,
+                         'Archive portlet is here but it should not be.')
+
+    @browsing
+    def test_archive_portlet_not_available_on_content_page(self, browser):
+        """
+        The events archive portlet is only rendered on events listing views.
+        """
+        page = create(Builder('sl content page').titled(u'Content Page'))
+        events_folder = create(Builder('event folder').titled(u'Event Folder')
+                               .with_property('layout', 'event_listing'))
+        create(Builder('event page').titled(u'Event Entry 1').within(events_folder))
+
+        self._add_portlet(browser, page)
+        self.assertNotIn('Archive', browser.css('dt.portletHeader').text,
+                         'Archive portlet is here but it should not be.')
+
+    @browsing
+    def test_archive_portlet_link(self, browser):
+        """
+        This test makes sure the summary is correct.
+        """
+        events_folder = create(Builder('event folder').titled(u'Event Folder')
+                               .with_property('layout', 'event_listing'))
+        create(Builder('event page').titled(u'Event Entry 1').within(events_folder)
+               .having(start=datetime(2013, 1, 1), end=datetime(2013, 1, 1)))
+        create(Builder('event page').titled(u'Event Entry 2').within(events_folder)
+               .having(start=datetime(2013, 1, 11), end=datetime(2013, 1, 11)))
+
+        self._add_portlet(browser, events_folder)
+
+        browser.css('.month').first.click()
+        self.assertEqual(2, len(browser.css('.event-item')))
+
+    @browsing
+    def test_month_with_umlaut(self, browser):
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.setDefaultLanguage('de')
+        transaction.commit()
+
+        events_folder = create(Builder('event folder').titled(u'Event Folder')
+                               .with_property('layout', 'event_listing'))
+        create(Builder('event page').titled(u'Event Entry 1').within(events_folder)
+               .having(start=datetime(2013, 3, 1), end=datetime(2013, 3, 1)))
+
+        self._add_portlet(browser, events_folder)
+
+        browser.css('.month').first.click()
+        self.assertEqual(1, len(browser.css('.event-item')))

--- a/ftw/events/upgrades/20190403192251_add_events_archive_portlet/jsregistry.xml
+++ b/ftw/events/upgrades/20190403192251_add_events_archive_portlet/jsregistry.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry"
+        autogroup="False">
+
+    <javascript cacheable="True"
+                compression="safe"
+                cookable="True"
+                enabled="True"
+                expression=""
+                id="++resource++ftw.events.resources/event-archive-portlet.js"
+                inline="False"/>
+
+</object>

--- a/ftw/events/upgrades/20190403192251_add_events_archive_portlet/portlets.xml
+++ b/ftw/events/upgrades/20190403192251_add_events_archive_portlet/portlets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<portlets>
+
+    <portlet
+        addview="eventsarchiveportlet"
+        title="Events Archive Portlet (ftw.events)"
+        description=""
+        />
+
+</portlets>

--- a/ftw/events/upgrades/20190403192251_add_events_archive_portlet/registry.xml
+++ b/ftw/events/upgrades/20190403192251_add_events_archive_portlet/registry.xml
@@ -1,19 +1,4 @@
 <registry>
-
-  <record name="plone.types_not_searched"
-          interface="Products.CMFPlone.interfaces.controlpanel.ISearchSchema"
-          field="types_not_searched">
-    <value>
-      <element>ftw.events.EventListingBlock</element>
-    </value>
-  </record>
-
-  <record name="plone.displayed_types">
-    <value purge="false">
-      <element>ftw.events.EventFolder</element>
-    </value>
-  </record>
-
   <records prefix="plone.resources/ftw.events_archive_portlet_js"
            interface="Products.CMFPlone.interfaces.IResourceRegistry">
     <value key="js">++resource++ftw.events.resources/event-archive-portlet.js</value>
@@ -32,5 +17,6 @@
     <value key="jscompilation">++plone++ftw.events/ftw-events-compiled.js</value>
     <value key="merge_with">default</value>
   </records>
-
 </registry>
+
+

--- a/ftw/events/upgrades/20190403192251_add_events_archive_portlet/upgrade.py
+++ b/ftw/events/upgrades/20190403192251_add_events_archive_portlet/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddEventsArchivePortlet(UpgradeStep):
+    """Add events archive portlet.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/ftw/events/upgrades/20190403192251_add_events_archive_portlet/upgrade.py
+++ b/ftw/events/upgrades/20190403192251_add_events_archive_portlet/upgrade.py
@@ -1,3 +1,4 @@
+from ftw.events.utils import IS_PLONE_5
 from ftw.upgrade import UpgradeStep
 
 
@@ -6,4 +7,7 @@ class AddEventsArchivePortlet(UpgradeStep):
     """
 
     def __call__(self):
-        self.install_upgrade_profile()
+        if IS_PLONE_5:
+            self.install_upgrade_profile(['plone.app.registry', 'portlets'])
+        else:
+            self.install_upgrade_profile(['jsregistry', 'portlets'])

--- a/ftw/events/utils.py
+++ b/ftw/events/utils.py
@@ -1,4 +1,8 @@
+from pkg_resources import get_distribution
 from plone import api
+
+
+IS_PLONE_5 = get_distribution('Plone').version >= '5'
 
 
 def get_creator(item):


### PR DESCRIPTION
For the event archive portlet to be working on the event folder itself, we need a new view. When we are in the simplelayout view there could be multiple event listing blocks, with each having different preferences. This results in a state where we would not know what to show in the events archive portlet (eg. one block has show old events on the other off). For this reason, we now have a new stripped down view for the EventFolder, which is an adaptation of the already existing event listing view from the event listing block.


![image](https://user-images.githubusercontent.com/9467802/55507293-a3b1e900-5657-11e9-853e-4f88992f9a08.png)
