### PR TITLE
Fix event archive portlet compatibility with ftw.news

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix event archive portlet compatibility issue with ftw.news [Nachtalb]
 
 
 1.11.0 (2019-05-14)

--- a/ftw/events/portlets/events_archive_portlet.py
+++ b/ftw/events/portlets/events_archive_portlet.py
@@ -179,12 +179,12 @@ class Renderer(base.Renderer):
         items = [{
             'title': year['title'],
             'count': year['number'],
-            'class': 'year expanded' if year['mark'] else 'year',
-            'months_expanded': 'months expanded' if year['mark'] else 'months',
+            'class': 'event-year expanded' if year['mark'] else 'event-year',
+            'months_expanded': 'event-months expanded' if year['mark'] else 'event-months',
             'months': [{
                 'title': month['title'],
                 'url': month['url'],
-                'class': 'month highlight' if month['mark'] else 'month',
+                'class': 'event-month highlight' if month['mark'] else 'event-month',
                 'month': month['title'],
                 'count': month['number'],
             } for month in year['months']],

--- a/ftw/events/portlets/templates/events_archive_portlet.pt
+++ b/ftw/events/portlets/templates/events_archive_portlet.pt
@@ -3,7 +3,7 @@
       tal:omit-tag="python: 1"
       i18n:domain="ftw.news">
 
-    <section class="portlet archive-portlet">
+    <section class="portlet event-archive-portlet">
 
         <header class="portletHeader">
             <h2 i18n:translate="">Archive</h2>

--- a/ftw/events/resources/event-archive-portlet.js
+++ b/ftw/events/resources/event-archive-portlet.js
@@ -27,7 +27,7 @@
   function openYear(year) { year.addClass("expanded"); }
 
   function closeMonth(year) {
-    $(".months", year.parent()).attr("aria-hidden", "true");
+    $(".event-months", year.parent()).attr("aria-hidden", "true");
   }
 
   function closeYear(year) {
@@ -44,13 +44,13 @@
   }
 
   function selectFirstMonth(year) {
-    $(".month", year.parent()).first().focus();
-    $(".months", year.parent()).attr("aria-hidden", "false");
+    $(".event-month", year.parent()).first().focus();
+    $(".event-months", year.parent()).attr("aria-hidden", "false");
   }
 
   var yearCarousel = {
     currentIndex: 0,
-    years: $(".year"),
+    years: $(".event-year"),
     next: function() {
       if(this.currentIndex === this.years.length - 1) {
         this.currentIndex = 0;
@@ -71,7 +71,7 @@
       this.years.eq(this.currentIndex).focus();
     },
     init: function(context) {
-      this.years = $(".year", context);
+      this.years = $(".event-year", context);
       this.currentIndex = 0;
     }
   };
@@ -104,17 +104,17 @@
     },
     init: function(year, index) {
       this.year = year;
-      this.months = $(".month", this.year.parent());
+      this.months = $(".event-month", this.year.parent());
       this.currentIndex = index || 0;
     }
   };
 
-  $(document).on("click", ".year", function(event) {
+  $(document).on("click", ".event-year", function(event) {
     event.preventDefault();
     toggleYear($(event.currentTarget));
   });
 
-  $(document).on("keydown", ".year", function(event) {
+  $(document).on("keydown", ".event-year", function(event) {
     var year = $(event.currentTarget);
     monthCarousel.init(year);
 
@@ -144,7 +144,7 @@
     }
   });
 
-  $(document).on("keydown", ".month", function(event) {
+  $(document).on("keydown", ".event-month", function(event) {
     var month = $(event.currentTarget);
 
     switch (event.which) {
@@ -167,7 +167,7 @@
     }
   });
 
-  $(document).on("keyup", ".month", function(event) {
+  $(document).on("keyup", ".event-month", function(event) {
     var month = $(event.currentTarget);
 
     switch (event.which) {
@@ -178,7 +178,7 @@
   });
 
   $(function() {
-    element = $(".archive-portlet");
+    element = $(".event-archive-portlet");
     yearCarousel.init(element);
   });
 

--- a/ftw/events/resources/event-archive-portlet.scss
+++ b/ftw/events/resources/event-archive-portlet.scss
@@ -1,4 +1,4 @@
-.archive-portlet {
+.event-archive-portlet {
   ul {
     @include list-tree($indentation: $line-height-base);
   }
@@ -7,7 +7,7 @@
     @include label-round();
   }
 
-  .year {
+  .event-year {
     @extend .fa-icon;
     @extend .fa-angle-right;
 
@@ -15,13 +15,13 @@
       @extend .fa-icon;
       @extend .fa-angle-down;
 
-      ~ .months {
+      ~ .event-months {
         display: block;
       }
     }
   }
 
-  .months {
+  .event-months {
     display: none;
   }
 }

--- a/ftw/events/tests/test_event_archive_portlets.py
+++ b/ftw/events/tests/test_event_archive_portlets.py
@@ -38,7 +38,7 @@ class TestEventArchivePortlets(FunctionalTestCase):
 
         self._add_portlet(browser, events_folder)
 
-        self.assertIn('Archive', browser.css('.archive-portlet header h2').text,
+        self.assertIn('Archive', browser.css('.event-archive-portlet header h2').text,
                       'Archive portlet is not here but it should be.')
 
     @browsing
@@ -70,7 +70,7 @@ class TestEventArchivePortlets(FunctionalTestCase):
         self.assertEqual(
             ['http://nohost/plone/event-folder/event_listing?archive=2013/02/01',
                 'http://nohost/plone/event-folder/event_listing?archive=2013/01/01'],
-            map(lambda month: month.attrib['href'], browser.css('.month')))
+            map(lambda month: month.attrib['href'], browser.css('.event-month')))
 
     @browsing
     def test_archive_portlet_not_available_on_plone_site(self, browser):
@@ -113,7 +113,7 @@ class TestEventArchivePortlets(FunctionalTestCase):
 
         self._add_portlet(browser, events_folder)
 
-        browser.css('.month').first.click()
+        browser.css('.event-month').first.click()
         self.assertEqual(2, len(browser.css('.event-item')))
 
     @browsing
@@ -129,5 +129,5 @@ class TestEventArchivePortlets(FunctionalTestCase):
 
         self._add_portlet(browser, events_folder)
 
-        browser.css('.month').first.click()
+        browser.css('.event-month').first.click()
         self.assertEqual(1, len(browser.css('.event-item')))


### PR DESCRIPTION
The functionality of the event archive portlet was copied from the news archive portlet. The html classes in both (ftw.news and ftw.events) were the same which meant that when ftw.news was installed next to ftw.events, both javascripts acted on both archive portlets. This had the effect that on click, the collapsible months were opened and immediately closed again.

By adding unique classes the news archive portlet javascript will not act on the event archive portlet anymore.