### PR TITLE
Fix typo in "Veranstalgungsauflistung" => "Veranstaltungsauflistung"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix typo in "Veranstalgungsauflistung" => "Veranstaltungsauflistung" [Nachtalb]
 
 
 1.11.1 (2019-05-14)

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -29,7 +29,7 @@ msgstr "Veranstaltungsordner"
 
 #: ./ftw/events/browser/configure.zcml:59
 msgid "Event Listing"
-msgstr "Veranstalgungsauflistung"
+msgstr "Veranstaltungsauflistung"
 
 #: ./ftw/events/profiles/default/types/ftw.events.EventPage.xml
 #: ./ftw/events/profiles/default_plone5/types/ftw.events.EventPage.xml


### PR DESCRIPTION
@maethu Do you see any other typos, I think this is only one.