### PR TITLE
Change sort order to match the same the EventListingBlock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Change sort order to match the same the EventListingBlock (next events on top) [Nachtalb]
 
 
 1.11.2 (2019-05-21)

--- a/ftw/events/browser/eventlisting.py
+++ b/ftw/events/browser/eventlisting.py
@@ -149,7 +149,6 @@ class EventListingFolder(EventListing):
         query = {
             'object_provides': 'ftw.events.interfaces.IEventPage',
             'sort_on': 'start',
-            'sort_order': 'reverse',
             'path': '/'.join(self.context.getPhysicalPath())
         }
 


### PR DESCRIPTION
The next events shall be on top not the one furthest away in the future