### PR TITLE
Fix event accessor location (eg. ics export now includes location)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix event accessor location field (includes features like location in the ics export) [Nachtalb]
 
 
 1.11.3 (2019-05-29)

--- a/ftw/events/browser/configure.zcml
+++ b/ftw/events/browser/configure.zcml
@@ -58,4 +58,5 @@
         action="event_listing"
         />
 
+    <adapter factory=".event_accessor.FtwEventAccessor" />
 </configure>

--- a/ftw/events/browser/event_accessor.py
+++ b/ftw/events/browser/event_accessor.py
@@ -1,0 +1,14 @@
+from ftw.events.contents.eventpage import IEventPageSchema
+from ftw.events.interfaces import IEventPage
+from plone.app.event.dx.behaviors import EventAccessor
+from plone.event.interfaces import IEventAccessor
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@adapter(IEventPageSchema)
+@implementer(IEventAccessor)
+class FtwEventAccessor(EventAccessor):
+    def __init__(self, context):
+        super(FtwEventAccessor, self).__init__(context)
+        self._behavior_map['location'] = IEventPage

--- a/ftw/events/tests/test_ics_view.py
+++ b/ftw/events/tests/test_ics_view.py
@@ -6,6 +6,7 @@ from ftw.events.tests import RealFuncitionalTestCase
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.pages import editbar
+import transaction
 import urlparse
 
 
@@ -34,6 +35,20 @@ class TestIsICSView(RealFuncitionalTestCase):
         self.assertIn('BEGIN:VEVENT', body)
         self.assertIn('END:VCALENDAR', body)
         self.assertIn('END:VEVENT', body)
+
+    @browsing
+    def test_location_in_ics(self, browser):
+        location = 'london baker street 221b'
+
+        browser.request_library = LIB_REQUESTS
+        browser.login().visit(self.event, view="ics_view")
+
+        self.assertNotIn(location, browser.contents)
+
+        self.event.location_title = location
+        transaction.commit()
+        browser.reload()
+        self.assertIn(location, browser.contents)
 
     @browsing
     def test_ics_view_is_ics_on_eventfolder(self, browser):


### PR DESCRIPTION
The event accessor implementation could not get the location of the `ftw.event.EventPage` events, because it did not use the same behaviour for the location as our EventPage. 
To fix this we adapt the event accessor ourselves. To get this to work we must use the events schema for the adapter because it higher up in the order than the default interface for the event accessor (`IDXEvent`) provided by the event, whereas the `IEventPage` is lower and so cannot be used.

With this fix everywhere the location is called via the event accessor the right location is not returned. This can be seen eg. in the ICS export and so we also tested it right there. 
