### PR TITLE
Merge pull request #50 from 4teamwork/ne/event-archiv-portlet-title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add customizable title to archive portlet [Nachtalb]
 
 
 1.11.4 (2019-07-25)

--- a/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
+++ b/ftw/events/locales/de/LC_MESSAGES/ftw.events.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-01 19:20+0000\n"
+"POT-Creation-Date: 2019-08-29 09:10+0000\n"
 "PO-Revision-Date: 2016-10-18 11:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
+
+#: ./ftw/events/portlets/templates/events_archive_portlet.pt:34
+msgid "<span class=\"title\">${DYNAMIC_CONTENT}</span> <span class=\"count\">${DYNAMIC_CONTENT}</span>"
+msgstr ""
 
 #: ./ftw/events/upgrades/20160915095729_add_ics_action/actions.xml
 msgid "Allows to export the event to a calendar app"
@@ -86,6 +90,11 @@ msgstr "Wann"
 msgid "Where"
 msgstr "Wo"
 
+#. Default: "Archive"
+#: ./ftw/events/portlets/events_archive_portlet.py:171
+msgid "archive"
+msgstr "Archive"
+
 #. Default: "Hide the block if there are not events to be shown."
 #: ./ftw/events/contents/eventlistingblock.py:181
 msgid "description_hide_empty_block"
@@ -115,6 +124,16 @@ msgstr "Wird nicht übersetzt."
 #: ./ftw/events/contents/eventlistingblock.py:172
 msgid "description_show_rss_link"
 msgstr "Einen Link zum RSS-Feed der Veranstaltungen anzeigen."
+
+#. Default: "Add Event Archive Portlet"
+#: ./ftw/events/portlets/events_archive_portlet.py:226
+msgid "event_archive_portlet_add"
+msgstr "Event Archiv Portlet Hinzufügen"
+
+#. Default: "Edit Event Archive Portlet"
+#: ./ftw/events/portlets/events_archive_portlet.py:257
+msgid "event_archive_portlet_edit"
+msgstr "Event Archiv Portlet Editieren"
 
 #. Default: "Show title"
 #: ./ftw/events/contents/eventlistingblock.py:72
@@ -222,6 +241,16 @@ msgstr "Dieser Block ist nur noch für Benutzer sichtbar, die Inhalte bearbeiten
 msgid "eventlisting_no_content_text"
 msgstr "Kein Inhalt verfügbar."
 
+#. Default: "Cancel"
+#: ./ftw/events/portlets/events_archive_portlet.py:293
+msgid "events_portlet_edit_form_cancel_label"
+msgstr "Abbrechen"
+
+#. Default: "Save"
+#: ./ftw/events/portlets/events_archive_portlet.py:276
+msgid "events_portlet_edit_form_save_label"
+msgstr "Speichern"
+
 #: ./ftw/events/profiles.zcml:17
 msgid "ftw.events"
 msgstr "ftw.events"
@@ -313,6 +342,11 @@ msgstr "Weitere Einträge"
 #: ./ftw/events/browser/eventlisting.py:98
 msgid "more_items_view_fallback_title"
 msgstr "Veranstaltungen"
+
+#. Default: "Title"
+#: ./ftw/events/portlets/events_archive_portlet.py:156
+msgid "title"
+msgstr "Titel"
 
 #. Default: "Events"
 #: ./ftw/events/contents/eventfolder.py:33

--- a/ftw/events/locales/ftw.events.pot
+++ b/ftw/events/locales/ftw.events.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-01 19:20+0000\n"
+"POT-Creation-Date: 2019-08-29 09:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
+
+#: ./ftw/events/portlets/templates/events_archive_portlet.pt:34
+msgid "<span class=\"title\">${DYNAMIC_CONTENT}</span> <span class=\"count\">${DYNAMIC_CONTENT}</span>"
+msgstr ""
 
 #: ./ftw/events/upgrades/20160915095729_add_ics_action/actions.xml
 msgid "Allows to export the event to a calendar app"
@@ -86,6 +90,11 @@ msgstr ""
 msgid "Where"
 msgstr ""
 
+#. Default: "Archive"
+#: ./ftw/events/portlets/events_archive_portlet.py:171
+msgid "archive"
+msgstr ""
+
 #. Default: "Hide the block if there are not events to be shown."
 #: ./ftw/events/contents/eventlistingblock.py:181
 msgid "description_hide_empty_block"
@@ -114,6 +123,16 @@ msgstr ""
 #. Default: "Render a link to the RSS feed of the events."
 #: ./ftw/events/contents/eventlistingblock.py:172
 msgid "description_show_rss_link"
+msgstr ""
+
+#. Default: "Add Event Archive Portlet"
+#: ./ftw/events/portlets/events_archive_portlet.py:226
+msgid "event_archive_portlet_add"
+msgstr ""
+
+#. Default: "Edit Event Archive Portlet"
+#: ./ftw/events/portlets/events_archive_portlet.py:257
+msgid "event_archive_portlet_edit"
 msgstr ""
 
 #. Default: "Show title"
@@ -222,6 +241,16 @@ msgstr ""
 msgid "eventlisting_no_content_text"
 msgstr ""
 
+#. Default: "Cancel"
+#: ./ftw/events/portlets/events_archive_portlet.py:293
+msgid "events_portlet_edit_form_cancel_label"
+msgstr ""
+
+#. Default: "Save"
+#: ./ftw/events/portlets/events_archive_portlet.py:276
+msgid "events_portlet_edit_form_save_label"
+msgstr ""
+
 #: ./ftw/events/profiles.zcml:17
 msgid "ftw.events"
 msgstr ""
@@ -312,6 +341,11 @@ msgstr ""
 #. Default: "Events"
 #: ./ftw/events/browser/eventlisting.py:98
 msgid "more_items_view_fallback_title"
+msgstr ""
+
+#. Default: "Title"
+#: ./ftw/events/portlets/events_archive_portlet.py:156
+msgid "title"
 msgstr ""
 
 #. Default: "Events"

--- a/ftw/events/portlets/configure.zcml
+++ b/ftw/events/portlets/configure.zcml
@@ -14,6 +14,7 @@
         view_permission="zope2.View"
         renderer=".events_archive_portlet.Renderer"
         addview=".events_archive_portlet.AddForm"
+        editview=".events_archive_portlet.EditForm"
         />
 
 </configure>

--- a/ftw/events/portlets/events_archive_portlet.py
+++ b/ftw/events/portlets/events_archive_portlet.py
@@ -1,20 +1,21 @@
-from plone.app.portlets.interfaces import IPortletPermissionChecker
-from Acquisition import aq_parent
 from Acquisition import aq_inner
-from zope.component import getMultiAdapter
+from Acquisition import aq_parent
 from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.i18nl10n import monthname_msgid
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.events import _
+from ftw.events.interfaces import IEventListingView
+from ftw.events.interfaces import IEventPage
+from plone.app.portlets.interfaces import IPortletPermissionChecker
 from plone.app.portlets.portlets import base
+from plone.directives.form.form import SchemaAddForm
 from plone.memoize.view import memoize
 from plone.portlets.interfaces import IPortletDataProvider
 from zope import schema
+from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import implements
-from plone.directives.form.form import SchemaAddForm
-from ftw.events.interfaces import IEventPage, IEventListingView
 
 
 def zLocalizedTime(request, time, long_format=False):

--- a/ftw/events/portlets/templates/events_archive_portlet.pt
+++ b/ftw/events/portlets/templates/events_archive_portlet.pt
@@ -6,7 +6,7 @@
     <section class="portlet event-archive-portlet">
 
         <header class="portletHeader">
-            <h2 i18n:translate="">Archive</h2>
+            <h2 tal:content="view/data/portlet_title"></h2>
         </header>
         <section class="portletItem">
           <ul class="years">

--- a/ftw/events/portlets/templates/events_archive_portlet.pt
+++ b/ftw/events/portlets/templates/events_archive_portlet.pt
@@ -1,7 +1,7 @@
 <html xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       tal:omit-tag="python: 1"
-      i18n:domain="ftw.news">
+      i18n:domain="ftw.events">
 
     <section class="portlet event-archive-portlet">
 

--- a/ftw/events/tests/test_event_archive_portlets.py
+++ b/ftw/events/tests/test_event_archive_portlets.py
@@ -27,6 +27,7 @@ class TestEventArchivePortlets(FunctionalTestCase):
         browser.login().visit(context, view='@@manage-portlets')
         browser.css('#portletmanager-plone-rightcolumn form')[0].fill(
             {':action': events_portlet_action}).submit()
+        browser.css('#form').first.fill({'Title': 'Archive'}).submit()
         browser.open(context)
 
     @browsing

--- a/ftw/events/tests/utils.py
+++ b/ftw/events/tests/utils.py
@@ -1,7 +1,10 @@
-from ftw.simplelayout.interfaces import IPageConfiguration
-from plone import api
-from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
+from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.testing import IS_PLONE_5
+from plone import api
+from plone.registry.interfaces import IRegistry
+from plone.uuid.interfaces import IUUID
+from zope.component import getUtility
 from zope.component.hooks import getSite
 import transaction
 
@@ -39,3 +42,42 @@ def enable_behavior(behavior, portal_type):
     behaviors.append(behavior)
     portal_types[portal_type].behaviors = tuple(behaviors)
     transaction.commit()
+
+
+class LanguageSetter(object):
+
+    def set_language_settings(self, default='en', supported=None,
+                              use_combined=False, start_neutral=True):
+        """
+        Sets language settings regardeless if plone4.3 or plone5.1
+        :param default: default site language
+        :param supported: list of supported languages
+        """
+        # startNeutral is not used/available in plone 5.1 anymore
+
+        if not supported:
+            supported = ['en']
+
+        if IS_PLONE_5:
+            from Products.CMFPlone.interfaces import ILanguageSchema
+
+            self.ltool = api.portal.get_tool('portal_languages')
+            self.ltool.setDefaultLanguage(default)
+            for lang in supported:
+                self.ltool.addSupportedLanguage(lang)
+            self.ltool.settings.use_combined_language_codes = False
+            self.ltool.setLanguageCookie()
+            registry = getUtility(IRegistry)
+            language_settings = registry.forInterface(ILanguageSchema, prefix='plone')
+            language_settings.use_content_negotiation = True
+        else:
+            self.ltool = self.portal.portal_languages
+            self.ltool.manage_setLanguageSettings(
+                default,
+                supported,
+                setUseCombinedLanguageCodes=use_combined,
+                # Set this only for better testing ability
+                setCookieEverywhere=True,
+                startNeutral=start_neutral,
+                setContentN=True)
+        transaction.commit()


### PR DESCRIPTION
A default title is given to the portlet so that existing ones will work as normal. 

The `LanguageSetter` in the tests was copied from `ftw.subsite`, it ensures that the correct language is used for plone 4 as well as plone 5. 

Editable event archive portlet
---
![image](https://user-images.githubusercontent.com/9467802/63940322-89930000-ca69-11e9-9ab9-c38484f6782b.png)

Title field 
---
![image](https://user-images.githubusercontent.com/9467802/63940327-8ac42d00-ca69-11e9-8301-3e9464397dd5.png)
