### PR TITLE
Add test for plone.app.event staging behaviour

### DIFF
--- a/ftw/events/tests/builders.py
+++ b/ftw/events/tests/builders.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from datetime import timedelta
 from ftw.builder import builder_registry
 from ftw.builder.dexterity import DexterityBuilder
 from ftw.simplelayout.tests import builders
@@ -19,6 +21,11 @@ class EventPageBuilder(DexterityBuilder):
         self.having(recurrence='')
         # using greenwich, since the test-site / browser is set up with it:
         self.having(timezone='Etc/Greenwich')
+        # Manually set start and end because an early import of IEventBasic
+        # in the `test_staging.py` results to events having no start and end
+        now = datetime.utcnow()
+        self.starting(now)
+        self.ending(now + timedelta(hours=1))
 
     def starting(self, date):
         if IS_PLONE_5:

--- a/ftw/events/tests/test_staging.py
+++ b/ftw/events/tests/test_staging.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.events.tests import FunctionalTestCase
+from ftw.simplelayout.staging.interfaces import IStaging
+from ftw.testbrowser import browsing
+from unittest2 import skipIf
+from ftw.testing import IS_PLONE_5
+from plone.event.utils import pydt
+from plone.app.event.dx.behaviors import IEventBasic
+
+
+@skipIf(IS_PLONE_5, 'Plone 5 has rewritten plone.app.events which makes this test obsolete')
+class TestWorkingCopy(FunctionalTestCase):
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.grant('Manager')
+
+    @browsing
+    def test_working_copy_apply_correct_event_dates(self, browser):
+        start = pydt(datetime(2013, 10, 7, 9))
+        end = pydt(datetime(2013, 10, 7, 16))
+        new_end = pydt(datetime(2013, 10, 7, 19))
+
+        folder = create(Builder('event folder'))
+        baseline = create(Builder('event page')
+                          .having(timezone='Europe/Zurich')
+                          .within(folder))
+
+        behaviour = IEventBasic(baseline)
+        behaviour.start, behaviour.end = start, end
+
+        self.assertEquals(start, behaviour.start)
+
+        working_copy = IStaging(baseline).create_working_copy(folder)
+        self.assertFalse(IStaging(baseline).is_working_copy())
+
+        working_behaviour = IEventBasic(working_copy)
+        working_behaviour.end = new_end
+        IStaging(working_copy).apply_working_copy()
+
+        self.assertEquals(new_end, behaviour.end)


### PR DESCRIPTION
**Situation**
`plone.app.events` replaces the timezone with a fake when setting `start` and `end`, without recalculating the DateTime to `UTC`. Because it has an own timezone field where the timezone is saved, it saves the `start` and `end` wrongly if it is given with a timezone other than the timezone set on the timezone field.
The getter for `start` and `end` however recalculates the DateTime with the timezone saved on the object. This means that the getter will return a different time than what the setter as been given to. Eg.:
```python
from plone.app.event.dx.behaviors import IEventBasic
from datetime import datetime
from pytz import timezone
from plone.event.utils import pydt

context.timezone = 'Europe/Zurich'
behaviour = IEventBasic(context)


start_date = pydt(datetime(2019, 1, 1, 10, tzinfo=pytz.timezone('Europe/Zurich')))

print start_date
# > datetime.datetime(2019, 1, 1, 10, 0, tzinfo=<DstTzInfo 'Europe/Zurich' CET+1:00:00 STD>)

behaviour.start = start_date
print behaviour.start
# > datetime.datetime(2019, 1, 1, 12, 0, tzinfo=<DstTzInfo 'Europe/Zurich' CET+1:00:00 STD>)

print behaviour.start == start
# > false
```

**Problem**
When applying a working copy via `ftw.simplelayout` it iterates over all fields and it's storages to get the values. This means it gets the value via the `IEventBasic` behaviour. And so it gets a value with a defined and calculated timezone. 
Now when we apply this onto the to the target via the behaviour the timezone is not considered and removed without recalculating the time. Which eventually leads to a wrong DateTime on the target object.

**Solution**
To fix this the issue we newly have a condition in `ftw.simplelayout` which gets the DateTime directly from the source object and so is not a DateTime with a recalculated timezone - meaning we can use it to set on the target object without any concerns. 

**PS** 
This behaviour of the `IEventBasic` behaviour was fixed in plone 5, so we don't have to test this.