### PR TITLE
Improve reindex_indexes install hook - to not reindex if not necessary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.14.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improve reindex_indexes install hook - to not reindex if not necessary. [mathias.leimgruber]
 
 
 1.14.1 (2019-12-14)

--- a/ftw/events/hooks.py
+++ b/ftw/events/hooks.py
@@ -14,5 +14,10 @@ def reindex_indexes(portal):
     the indexes.
     """
     catalog = getToolByName(portal, 'portal_catalog')
-    catalog.reindexIndex('start', None)
-    catalog.reindexIndex('end', None)
+
+    # Only reindex start/end if the index is empty
+    if len(catalog.Indexes['start']):
+        catalog.reindexIndex('start', None)
+
+    if len(catalog.Indexes['end']):
+        catalog.reindexIndex('end', None)


### PR DESCRIPTION
In case of a "reinstall", this is for example not necessary. 