### PR TITLE
Only install p.a.referenceablebehavior on Plone 4 with a "plone4" extra

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix german formatted date translation for open-ended events [Nachtalb]
 - Fix plone 5 upgrade step, which accidentally broke ftw.keywordwidget [mathias.leimgruber]
+- Remove obsolete dependency from Plone 5. From now on install the "plone4" extra for Plone 4 installations [Nachtalb]
 
 
 1.14.4 (2020-01-09)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ extras_require = {
         'plonetheme.blueberry',
         'ftw.events[mopage_publisher_receiver]',
     ],
-
+    'plone4': [
+        'plone.app.referenceablebehavior',
+    ],
     # The mopage_publisher_receiver should be installed on a ftw.publisher
     # receiver installation in order to enable the mopage trigger function.
     # It should *NOT* be installed on ftw.pubsliher.sender site, since
@@ -73,7 +75,6 @@ setup(
         'plone.api',
         'plone.app.dexterity',
         'plone.app.event [dexterity]',
-        'plone.app.referenceablebehavior',
         'plone.directives.form',
         'setuptools',
     ],

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,6 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.events
+test-egg = ftw.events [plone4, tests]
 
 [versions]
 # Plone 4 support got dropped in 1.4.0


### PR DESCRIPTION
p.a.referenceablebehavior is not compatible with plone 5 and breaks
stuff when it is used. It was not used in here anymore but with
ftw.events we installed it and if another package falsely still used it,
it broke the installation.