### PR TITLE
Respect syndications settings on EventFolder RSS viewlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Fix plone 5 upgrade step, which accidentally broke ftw.keywordwidget [mathias.leimgruber]
 - Remove obsolete dependency from Plone 5. From now on install the "plone4" extra for Plone 4 installations [Nachtalb]
 - Add possibility to show a leadimage within the block. [busykoala]
+- Respect syndications settings on EventFolder RSS viewlet. [mathias.leimgruber]
 
 
 1.14.4 (2020-01-09)

--- a/ftw/events/tests/test_mopage_export.py
+++ b/ftw/events/tests/test_mopage_export.py
@@ -189,7 +189,7 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
 
     def assert_events_in_browser(self, expected_titles):
         got_titles = browser.css('titel').text
-        self.assertEquals(expected_titles, got_titles)
+        self.assertItemsEqual(expected_titles, got_titles)
 
     def get_links_from_response(self):
         def parse_link(text):

--- a/ftw/events/viewlets/rsslink.py
+++ b/ftw/events/viewlets/rsslink.py
@@ -1,8 +1,11 @@
 from ftw.events.interfaces import IEventListingBlock
 from plone import api
 from plone.app.layout.links.viewlets import RSSViewlet
+from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.interfaces.syndication import IFeedSettings
+from Products.CMFPlone.interfaces.syndication import ISiteSyndicationSettings
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import getUtility
 
 
 class EventFolderRSSViewlet(RSSViewlet):
@@ -16,8 +19,13 @@ class EventFolderRSSViewlet(RSSViewlet):
     def update(self):
         super(EventFolderRSSViewlet, self).update()
         self.rsslinks = []
-        for block in self.get_blocks_with_syndication_enabled():
-            self.rsslinks.extend(self.getRssLinks(block))
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISiteSyndicationSettings)
+
+        if settings.allowed:
+            for block in self.get_blocks_with_syndication_enabled():
+                self.rsslinks.extend(self.getRssLinks(block))
 
     def get_blocks_with_syndication_enabled(self):
         blocks = api.content.find(


### PR DESCRIPTION
Before the syndication links in the html head were rendered anyway regardless of the configuration, which lead to a "NotFound" if actually followed that link.