### PR TITLE
Add more info to rss feed and use Event start date as pubDate.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add more info to rss feed and use Event start date as pubDate. [mathias.leimgruber]
 
 
 1.15.0 (2020-07-27)

--- a/ftw/events/browser/eventlisting.py
+++ b/ftw/events/browser/eventlisting.py
@@ -130,6 +130,9 @@ class EventListingRss(EventListing):
     def get_item_link(self, url):
         return '<link>{}</link>'.format(url)
 
+    def get_rfc822_datetime(self, datetime_obj):
+        return DateTime(datetime_obj).rfc822()
+
 
 class EventListingFolder(EventListing):
     """

--- a/ftw/events/browser/templates/events_rss.pt
+++ b/ftw/events/browser/templates/events_rss.pt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0"
      xmlns:tal="http://xml.zope.org/namespaces/tal"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:atom="http://www.w3.org/2005/Atom">
     <channel tal:define="items view/get_items">
         <atom:link tal:attributes="href string:${view/context/absolute_url}/${view/__name__}"
@@ -14,9 +15,14 @@
             <tal:link tal:replace="structure python:view.get_item_link(item.getURL())">link</tal:link>
             <description tal:content="item/Description" />
             <guid tal:content="item/getURL" />
-            <pubDate tal:define="effective item/effective"
-                     tal:condition="effective"
-                     tal:content="effective/rfc822" />
+            <lastBuildDate tal:content="item/modified/rfc822" />
+            <pubDate tal:define="start item/start"
+                     tal:condition="start"
+                     tal:content="python: view.get_rfc822_datetime(start)" />
+            <dc:subject tal:repeat="subject item/Subject">
+                <tal:subject replace="subject" />
+            </dc:subject>
+            <dc:type tal:content="item/portal_type" />
         </item>
     </channel>
 </rss>

--- a/ftw/events/tests/test_rss_view.py
+++ b/ftw/events/tests/test_rss_view.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from datetime import datetime
 from datetime import timedelta
 from ftw.builder import Builder
@@ -62,3 +63,9 @@ class TestRssView(FunctionalTestCase):
         self.assertEqual(['http://nohost/plone/events/an-event',
                           'http://nohost/plone/events/a-second-event'],
                          browser.css('rss channel item link').text)
+        self.assertEqual([DateTime(self.event_1.start).rfc822(), DateTime(self.event_2.start).rfc822()],
+                         browser.css('rss item pubDate').text)
+        self.assertEqual([self.event_1.modified().rfc822(), self.event_2.modified().rfc822()],
+                         browser.css('rss item lastBuildDate').text)
+        self.assertEqual(['ftw.events.EventPage', 'ftw.events.EventPage'],
+                         browser.xpath('//dc:type').text)


### PR DESCRIPTION
Example output:

```xml
<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
<channel>
<atom:link rel="self" type="application/rss+xml" href="http://localhost:8080/Plone1/events-1/veranstaltungen/events_rss"/>
<title>Veranstaltungen</title>
<link>http://localhost:8080/Plone1/events-1/veranstaltungen/events_rss</link>
<description>Veranstaltungen - Veranstaltungs Feed</description>
<item>
<title>Ein Event</title>
<link>http://localhost:8080/Plone1/events-1/ein-event</link>
<description/>
<guid>http://localhost:8080/Plone1/events-1/ein-event</guid>
<lastBuildDate>Wed, 02 Sep 2020 09:17:31 +0200</lastBuildDate>
<pubDate>Tue, 01 Sep 2020 09:00:00 +0200</pubDate>
<dc:subject> üüüüüü </dc:subject>
<dc:subject> tag1 </dc:subject>
<dc:subject> tag2 </dc:subject>
<dc:subject> tag3 </dc:subject>
<dc:type>ftw.events.EventPage</dc:type>
</item>
</channel>
</rss>
``` 